### PR TITLE
Fix #5: Fix deprecation warnings regarding class constructors

### DIFF
--- a/cmsimple/classes/Backup.php
+++ b/cmsimple/classes/Backup.php
@@ -65,12 +65,24 @@ class XH_Backup
      *
      * @global array The configuration of the core.
      */
-    function XH_Backup($contentFolders)
+    function __construct($contentFolders)
     {
         global $cf;
 
         $this->_contentFolders = $contentFolders;
         $this->_maxBackups = (int) $cf['backup']['numberoffiles'];
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param array $contentFolders An array of foldernames.
+     *
+     * @return void
+     */
+    function XH_Backup($contentFolders)
+    {
+        XH_Backup::__construct($contentFolders);
     }
 
     /**

--- a/cmsimple/classes/CSRFProtection.php
+++ b/cmsimple/classes/CSRFProtection.php
@@ -53,7 +53,7 @@ class XH_CSRFProtection
      *
      * @return void
      */
-    function XH_CSRFProtection($keyName = 'xh_csrf_token', $perRequest = false)
+    function __construct($keyName = 'xh_csrf_token', $perRequest = false)
     {
         $this->keyName = $keyName;
         if (!$perRequest) {
@@ -64,6 +64,20 @@ class XH_CSRFProtection
                 $this->token = $_SESSION[$this->keyName][CMSIMPLE_ROOT];
             }
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param string $keyName    A key name.
+     * @param bool   $perRequest Whether a new token shall be generated for each
+     *                           request (otherwise once per session).
+     *
+     * @return void
+     */
+    function XH_CSRFProtection($keyName = 'xh_csrf_token', $perRequest = false)
+    {
+        XH_CSRFProtection::__construct($keyName, $perRequest);
     }
 
     /**

--- a/cmsimple/classes/FileEdit.php
+++ b/cmsimple/classes/FileEdit.php
@@ -170,7 +170,7 @@ class XH_TextFileEdit extends XH_FileEdit
      *
      * @access protected
      */
-    function XH_TextFileEdit()
+    function __construct()
     {
         $contents = XH_readFile($this->filename);
         if ($contents !== false) {
@@ -179,6 +179,18 @@ class XH_TextFileEdit extends XH_FileEdit
             e('cntopen', 'file', $this->filename);
             $this->text = '';
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access protected
+     */
+    function XH_TextFileEdit()
+    {
+        XH_TextFileEdit::__construct();
     }
 
     /**
@@ -287,7 +299,7 @@ class XH_CoreTextFileEdit extends XH_TextFileEdit
      *
      * @access public
      */
-    function XH_CoreTextFileEdit()
+    function __construct()
     {
         global $pth, $file, $tx;
 
@@ -297,6 +309,18 @@ class XH_CoreTextFileEdit extends XH_TextFileEdit
         $this->redir = "?file=$file&action=edit&xh_success=$file";
         $this->textareaName = 'text';
         parent::XH_TextFileEdit();
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_CoreTextFileEdit()
+    {
+        XH_CoreTextFileEdit::__construct();
     }
 }
 
@@ -324,7 +348,7 @@ class XH_PluginTextFileEdit extends XH_TextFileEdit
      *
      * @access public
      */
-    function XH_PluginTextFileEdit()
+    function __construct()
     {
         global $pth, $plugin, $tx;
 
@@ -338,6 +362,18 @@ class XH_PluginTextFileEdit extends XH_TextFileEdit
         $this->caption = utf8_ucfirst($plugin) . ' &ndash; '
             . utf8_ucfirst($tx['filetype']['stylesheet']);
         parent::XH_TextFileEdit();
+    }
+
+    /**
+     * Fallback constructor for PHP 4.
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_PluginTextFileEdit()
+    {
+        XH_PluginTextFileEdit::__construct();
     }
 }
 
@@ -391,7 +427,7 @@ class XH_ArrayFileEdit extends XH_FileEdit
      *
      * @return void
      */
-    function XH_ArrayFileEdit()
+    function __construct()
     {
         if (is_readable($this->metaLangFile)) {
             include $this->metaLangFile;
@@ -399,6 +435,16 @@ class XH_ArrayFileEdit extends XH_FileEdit
         } else {
             $this->lang = array();
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     */
+    function XH_ArrayFileEdit()
+    {
+        XH_ArrayFileEdit::__construct();
     }
 
     /**
@@ -828,7 +874,7 @@ class XH_CoreArrayFileEdit extends XH_ArrayFileEdit
      *
      * @access protected
      */
-    function XH_CoreArrayFileEdit()
+    function __construct()
     {
         global $pth, $sl, $file, $tx;
 
@@ -836,6 +882,18 @@ class XH_CoreArrayFileEdit extends XH_ArrayFileEdit
         $this->caption = utf8_ucfirst($tx['filetype'][$file]);
         $this->metaLangFile = $pth['folder']['language'] . 'meta' . $sl . '.php';
         parent::XH_ArrayFileEdit();
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access protected
+     */
+    function XH_CoreArrayFileEdit()
+    {
+        XH_CoreArrayFileEdit::__construct();
     }
 
     /**
@@ -912,7 +970,7 @@ class XH_CoreConfigFileEdit extends XH_CoreArrayFileEdit
      *
      * @access public
      */
-    function XH_CoreConfigFileEdit()
+    function __construct()
     {
         global $pth, $cf, $tx;
 
@@ -950,6 +1008,18 @@ class XH_CoreConfigFileEdit extends XH_CoreArrayFileEdit
             }
         }
     }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_CoreConfigFileEdit()
+    {
+        XH_CoreConfigFileEdit::__construct();
+    }
 }
 
 
@@ -976,7 +1046,7 @@ class XH_CoreLangFileEdit extends XH_CoreArrayFileEdit
      *
      * @access public
      */
-    function XH_CoreLangFileEdit()
+    function __construct()
     {
         global $sl, $cf, $tx;
 
@@ -1011,6 +1081,18 @@ class XH_CoreLangFileEdit extends XH_CoreArrayFileEdit
                 $this->cfg[$cat][$name] = $co;
             }
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_CoreLangFileEdit()
+    {
+        XH_CoreConfigFileEdit::__construct();
     }
 }
 
@@ -1049,7 +1131,7 @@ class XH_PluginArrayFileEdit extends XH_ArrayFileEdit
      *
      * @access protected
      */
-    function XH_PluginArrayFileEdit()
+    function __construct()
     {
         global $pth, $sl, $plugin;
 
@@ -1057,6 +1139,18 @@ class XH_PluginArrayFileEdit extends XH_ArrayFileEdit
         $this->metaLangFile = $pth['folder']['plugins'] . $plugin
             . '/languages/meta' . $sl . '.php';
         parent::XH_ArrayFileEdit();
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access protected
+     */
+    function XH_PluginArrayFileEdit()
+    {
+        XH_PluginArrayFileEdit::__construct();
     }
 
     /**
@@ -1108,7 +1202,7 @@ class XH_PluginConfigFileEdit extends XH_PluginArrayFileEdit
      *
      * @access public
      */
-    function XH_PluginConfigFileEdit()
+    function __construct()
     {
         global $pth, $plugin, $tx, $plugin_cf, $plugin_tx;
 
@@ -1137,6 +1231,18 @@ class XH_PluginConfigFileEdit extends XH_PluginArrayFileEdit
             $this->cfg[$cat][$name] = $this->option($omcf, $val, $hint);
         }
     }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_PluginConfigFileEdit()
+    {
+        XH_PluginConfigFileEdit::__construct();
+    }
 }
 
 
@@ -1164,7 +1270,7 @@ class XH_PluginLanguageFileEdit extends XH_PluginArrayFileEdit
      *
      * @access public
      */
-    function XH_PluginLanguageFileEdit()
+    function __construct()
     {
         global $pth, $plugin, $tx, $plugin_tx;
 
@@ -1183,6 +1289,18 @@ class XH_PluginLanguageFileEdit extends XH_PluginArrayFileEdit
             $co = array('val' => $val, 'type' => 'text');
             $this->cfg[$cat][$name] = $co;
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_PluginLanguageFileEdit()
+    {
+        XH_PluginLanguageFileEdit::__construct();
     }
 }
 

--- a/cmsimple/classes/JSON.php
+++ b/cmsimple/classes/JSON.php
@@ -174,7 +174,7 @@ class XH_JSON
      *
      * @access public
      */
-    function XH_JSON()
+    function __construct()
     {
         $this->first = array(
             'object' => array(XH_JSON_LBRACE),
@@ -185,6 +185,18 @@ class XH_JSON
                 XH_JSON_TRUE, XH_JSON_FALSE, XH_JSON_NULL
             )
         );
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_JSON()
+    {
+        XH_JSON::__construct();
     }
 
     /**

--- a/cmsimple/classes/Mailform.php
+++ b/cmsimple/classes/Mailform.php
@@ -121,7 +121,7 @@ class XH_Mailform
      *
      * @access public
      */
-    function XH_Mailform($embedded = false, $subject=null)
+    function __construct($embedded = false, $subject=null)
     {
         global $cf, $tx;
         $this->embedded = $embedded;
@@ -156,6 +156,23 @@ class XH_Mailform
             $this->mailform = isset($_POST['mailform'])
                 ? stsl($_POST['mailform']) : '';
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param bool   $embedded Whether the mailform is embedded on a CMSimple_XH
+     *                         page.
+     * @param string $subject  An alternative subject field preset text instead of 
+     *                         the subject default in localization.
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_Mailform($embedded = false, $subject=null)
+    {
+        XH_Mailform::__construct($embedded, $subject);
     }
 
     /**

--- a/cmsimple/classes/PageDataModel.php
+++ b/cmsimple/classes/PageDataModel.php
@@ -86,7 +86,7 @@ class XH_PageDataModel
      *
      * @access public
      */
-    function XH_PageDataModel($h, $pageDataFields, $tempData, $pageData)
+    function __construct($h, $pageDataFields, $tempData, $pageData)
     {
         $this->headings = $h;
         $this->params = !empty($pageDataFields)
@@ -95,6 +95,23 @@ class XH_PageDataModel
         $this->temp_data = $tempData;
         $this->data = $pageData;
         $this->fixUp();
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param array $h              The page headings.
+     * @param array $pageDataFields The page data fields.
+     * @param array $tempData       The most recently deleted page data.
+     * @param array $pageData       The page data.
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_PageDataModel($h, $pageDataFields, $tempData, $pageData)
+    {
+        XH_PageDataModel::__construct($h, $pageDataFields, $tempData, $pageData);
     }
 
     /**

--- a/cmsimple/classes/PageDataRouter.php
+++ b/cmsimple/classes/PageDataRouter.php
@@ -66,7 +66,7 @@ class XH_PageDataRouter
      *
      * @access public
      */
-    function XH_PageDataRouter($h, $pageDataFields, $tempData, $pageData)
+    function __construct($h, $pageDataFields, $tempData, $pageData)
     {
         $this->model = new XH_PageDataModel(
             $h, $pageDataFields, $tempData, $pageData
@@ -74,6 +74,23 @@ class XH_PageDataRouter
     }
 
     /**
+     * Fallback constructor for PHP 4
+     *
+     * @param array $h              The page headings.
+     * @param array $pageDataFields The page data fields.
+     * @param array $tempData       The most recently deleted page data.
+     * @param array $pageData       The page data.
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_PageDataRouter($h, $pageDataFields, $tempData, $pageData)
+    {
+        XH_PageDataRouter::__construct($h, $pageDataFields, $tempData, $pageData);
+    }
+
+   /**
      * Returns all fields that are stored in the page data.
      *
      * @return array

--- a/cmsimple/classes/PageDataView.php
+++ b/cmsimple/classes/PageDataView.php
@@ -54,10 +54,25 @@ class XH_PageDataView
      *
      * @access public
      */
-    function XH_PageDataView($page, $tabs = null)
+    function __construct($page, $tabs = null)
     {
         $this->page = $page;
         $this->tabs = $tabs;
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param array $page Data of the page.
+     * @param array $tabs The filenames of the views of page data tabs.
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function XH_PageDataView($page, $tabs = null)
+    {
+        XH_PageDataView::__construct($page, $tabs);
     }
 
     /**

--- a/cmsimple/classes/Pages.php
+++ b/cmsimple/classes/Pages.php
@@ -91,7 +91,7 @@ class XH_Pages
      * @global array The menu levels of the pages.
      * @global array The contents of the pages.
      */
-    function XH_Pages()
+    function __construct()
     {
         global $h, $u, $l, $c;
 
@@ -100,6 +100,16 @@ class XH_Pages
         $this->urls = $u;
         $this->contents = $c;
         $this->levels = $l;
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     */
+    function XH_Pages()
+    {
+        XH_Pages::__construct();
     }
 
     /**

--- a/cmsimple/classes/PasswordHash.php
+++ b/cmsimple/classes/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
@@ -43,6 +43,11 @@ class PasswordHash {
 		$this->random_state = microtime();
 		if (function_exists('getmypid'))
 			$this->random_state .= getmypid();
+	}
+
+	function PasswordHash($iteration_count_log2, $portable_hashes)
+	{
+		PasswordHash::__construct($iteration_count_log2, $portable_hashes);
 	}
 
 	function get_random_bytes($count)

--- a/cmsimple/classes/PluginMenu.php
+++ b/cmsimple/classes/PluginMenu.php
@@ -143,11 +143,23 @@ class XH_PluginMenu
      *
      * @global string The script name.
      */
-    function XH_PluginMenu()
+    function __construct()
     {
         global $sn;
 
         $this->scriptName = $sn;
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @global string The script name.
+     */
+    function XH_PluginMenu()
+    {
+        XH_PluginMenu::__construct();
     }
 
     /**
@@ -268,10 +280,20 @@ class XH_ClassicPluginMenu extends XH_PluginMenu
      *
      * @return void
      */
-    function XH_ClassicPluginMenu()
+    function __construct()
     {
         parent::XH_PluginMenu();
         $this->_menu = '';
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     */
+    function XH_ClassicPluginMenu()
+    {
+        XH_ClassicPluginMenu::__construct();
     }
 
     /**

--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -72,9 +72,21 @@ class XH_Search
      *
      * @return void
      */
-    function XH_Search($searchString)
+    function __construct($searchString)
     {
         $this->searchString = $searchString;
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param string $searchString String The search string.
+     *
+     * @return void
+     */
+    function XH_Search($searchString)
+    {
+        XH_Search::__construct($searchString);
     }
 
     /**

--- a/plugins/filebrowser/classes/Filebrowser_Controller.php
+++ b/plugins/filebrowser/classes/Filebrowser_Controller.php
@@ -135,7 +135,7 @@ class Filebrowser_Controller
      * @global array The paths of system files and folders.
      * @global array The configuration of the plugins.
      */
-    function Filebrowser_Controller()
+    function __construct()
     {
         global $pth, $plugin_cf;
 
@@ -153,6 +153,16 @@ class Filebrowser_Controller
                 }
             }
         }
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     */
+    function Filebrowser_Controller()
+    {
+        Filebrowser_Controller::__construct();
     }
 
     /**

--- a/plugins/filebrowser/classes/Filebrowser_View.php
+++ b/plugins/filebrowser/classes/Filebrowser_View.php
@@ -164,11 +164,23 @@ class Filebrowser_View
      *
      * @access public
      */
-    function Filebrowser_View()
+    function __construct()
     {
         global $plugin_tx;
 
         $this->lang = $plugin_tx['filebrowser'];
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     *
+     * @access public
+     */
+    function Filebrowser_View()
+    {
+        Filebrowser_View::__construct();
     }
 
     /**

--- a/plugins/pagemanager/classes/Controller.php
+++ b/plugins/pagemanager/classes/Controller.php
@@ -46,12 +46,22 @@ class Pagemanager_Controller
      *
      * @return void
      */
-    function Pagemanager_Controller()
+    function __construct()
     {
         global $pth;
 
         include_once $pth['folder']['plugin_classes'] . 'Model.php';
         $this->model = new Pagemanager_Model();
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @return void
+     */
+    function Pagemanager_Controller()
+    {
+        Pagemanager_Controller::__construct();
     }
 
     /**

--- a/plugins/pagemanager/classes/XMLParser.php
+++ b/plugins/pagemanager/classes/XMLParser.php
@@ -124,11 +124,25 @@ class Pagemanager_XMLParser
      *
      * @return void
      */
-    function Pagemanager_XMLParser($contents, $levels, $pdattrName)
+    function __construct($contents, $levels, $pdattrName)
     {
         $this->contents = $contents;
         $this->levels = $levels;
         $this->pdattrName = $pdattrName;
+    }
+
+    /**
+     * Fallback constructor for PHP 4
+     *
+     * @param array  $contents   Page contents.
+     * @param int    $levels     Maximum page level.
+     * @param string $pdattrName Name of a page data attribute.
+     *
+     * @return void
+     */
+    function Pagemanager_XMLParser($contents, $levels, $pdattrName)
+    {
+        Pagemanager_XMLParser::__construct($contents, $levels, $pdattrName);
     }
 
     /**


### PR DESCRIPTION
We're avoiding the deprecation warnings regarding PHP 4 class
constructors under PHP 7 by using proper PHP 5 constructors and
additionally having PHP 4 constructors as fallback.