### PR TITLE
Fix #7: Don't show generator=CMSimple_XH in HTML header

### DIFF
--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -82,13 +82,16 @@ function head()
     $t = tag('meta http-equiv="content-type" content="text/html;charset=UTF-8"')
         . "\n" . $t;
     $plugins = implode(', ', XH_plugins());
-    return $t
-        . tag(
-            'meta name="generator" content="' . CMSIMPLE_XH_VERSION . ' '
-            . CMSIMPLE_XH_BUILD . ' - www.cmsimple-xh.org"'
-        ) . "\n"
-        . '<!-- plugins: ' . $plugins . ' -->' . "\n"
-        . XH_renderPrevLink() . XH_renderNextLink()
+    $o = $t;
+    if (error_reporting() > 0) {
+        $o .=
+            tag(
+                'meta name="generator" content="' . CMSIMPLE_XH_VERSION . ' '
+                . CMSIMPLE_XH_BUILD . ' - www.cmsimple-xh.org"'
+            ) . "\n"
+            . '<!-- plugins: ' . $plugins . ' -->' . "\n";
+    }
+    $o .= XH_renderPrevLink() . XH_renderNextLink()
         . tag(
             'link rel="stylesheet" href="' . $pth['file']['corestyle']
             . '" type="text/css"'
@@ -98,6 +101,7 @@ function head()
             . '" type="text/css"'
         ) . "\n"
         . $hjs;
+    return $o;
 }
 
 /**

--- a/tests/unit/HeadTest.php
+++ b/tests/unit/HeadTest.php
@@ -168,9 +168,9 @@ class HeadTest extends PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testRendersMetaGenerator()
+    public function testDoesNotRenderMetaGenerator()
     {
-        @$this->assertTag(
+        @$this->assertNotTag(
             array(
                 'tag' => 'meta',
                 'attributes' => array(


### PR DESCRIPTION
For security reasons we don't want to show the CMSimple_XH version and
info about installed plugins in the generated HTML sources by default.
Instead we show this info only, if the debug-mode is enabled (as
suggested by olape), so supporters would still be able to view this
information without access to the back-end.