### PR TITLE
Fix #2: File rename bug in filebrowser plugin

### DIFF
--- a/plugins/filebrowser/classes/Filebrowser_Controller.php
+++ b/plugins/filebrowser/classes/Filebrowser_Controller.php
@@ -602,7 +602,7 @@ class Filebrowser_Controller
     function renameFile()
     {
         $newName = str_replace(
-            array('..', '<', '>', ':', '?', ' '), '', basename($_POST['renameFile'])
+            array('..', '<', '>', ':', '?'), '', basename($_POST['renameFile'])
         );
         $oldName = $_POST['oldName'];
         if ($oldName == $newName) {


### PR DESCRIPTION
We don't think that it makes sense to disallow spaces when renaming a
file, but to allow them when uploading a file, so we remove space from
the list of ignored characters.