### PR TITLE
Fix #3: Search doesn't cater to alternative headings

### DIFF
--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -153,9 +153,13 @@ class XH_Search
      */
     function prepareContent($content, $pageIndex)
     {
-        global $s;
+        global $s, $pd_router;
 
         $s = $pageIndex;
+        $pageData = $pd_router->find_page($s);
+        if (function_exists('Pageparams_replaceAlternativeHeading')) {
+            $content = Pageparams_replaceAlternativeHeading($content, $pageData);
+        }
         $content = strip_tags(evaluate_plugincall($content));
         $s = -1;
         if (method_exists('Normalizer', 'normalize')) {

--- a/plugins/page_params/index.php
+++ b/plugins/page_params/index.php
@@ -150,14 +150,13 @@ function Pageparams_switchTemplate($n)
  *
  * @return string
  *
- * @global array The contents of the pages.
  * @global array The configuration of the core.
  *
  * @since 1.6.10
  */
 function Pageparams_replaceAlternativeHeading($content, $pageData)
 {
-    global $c, $cf;
+    global $cf;
 
     if ($pageData['show_heading'] == '1') {
         $pattern = '/(<h[1-' . $cf['menu']['levels'] . '].*>).+(<\/h[1-'
@@ -170,6 +169,8 @@ function Pageparams_replaceAlternativeHeading($content, $pageData)
                 $content
             );
         }
+    } else {
+        return $content;
     }
 }
 

--- a/plugins/page_params/index.php
+++ b/plugins/page_params/index.php
@@ -142,6 +142,37 @@ function Pageparams_switchTemplate($n)
     }
 }
 
+/**
+ * Replaces the existing heading with an alternative heading if configured.
+ *
+ * @param string $content  The page content.
+ * @param array  $pageData The page data.
+ *
+ * @return string
+ *
+ * @global array The contents of the pages.
+ * @global array The configuration of the core.
+ *
+ * @since 1.6.10
+ */
+function Pageparams_replaceAlternativeHeading($content, $pageData)
+{
+    global $c, $cf;
+
+    if ($pageData['show_heading'] == '1') {
+        $pattern = '/(<h[1-' . $cf['menu']['levels'] . '].*>).+(<\/h[1-'
+            . $cf['menu']['levels'] . ']>)/isU';
+        if (trim($pageData['heading']) == '') {
+            return preg_replace($pattern, '', $content);
+        } else {
+            return preg_replace(
+                $pattern, '${1}' . addcslashes($pageData['heading'], '$\\') . '$2',
+                $content
+            );
+        }
+    }
+}
+
 /*
  * Add used interests to router.
  */
@@ -173,18 +204,7 @@ Pageparams_switchTemplate($pd_s);
  * Override defaults by page-parameters but only if not in edit-mode.
  */
 if (!$edit && $pd_current) {
-    if ($pd_current['show_heading'] == '1') {
-        $temp = '/(<h[1-' . $cf['menu']['levels'] . '].*>).+(<\/h[1-'
-            . $cf['menu']['levels'] . ']>)/isU';
-        if (trim($pd_current['heading']) == '') {
-            $c[$pd_s] = preg_replace($temp, '', $c[$pd_s]);
-        } else {
-            $c[$pd_s] = preg_replace(
-                $temp, '${1}' . addcslashes($pd_current['heading'], '$\\') . '$2',
-                $c[$pd_s]
-            );
-        }
-    }
+    $c[$pd_s] = Pageparams_replaceAlternativeHeading($c[$pd_s], $pd_current);
     if ($pd_current['show_last_edit'] > 0
         && $pd_current['last_edit'] !== ''
     ) {

--- a/tests/unit/SearchTest.php
+++ b/tests/unit/SearchTest.php
@@ -35,7 +35,7 @@ class SearchTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        global $c, $cf;
+        global $c, $cf, $pd_router;
 
         $c = array(
             '<h1>Welcome to CMSimple_XH</h1>',
@@ -43,9 +43,37 @@ class SearchTest extends PHPUnit_Framework_TestCase
             'More about CMSimple.',
             '#CMSimple hide# CMSimple again',
             'Bill &amp; Ted',
-            "se\xC3\xB1or"
+            "se\xC3\xB1or",
+            '<h1>foo</h1>'
         );
+        $h = array('a', 'b', 'c', 'd', 'e', 'f');
+        $fields = array('show_heading', 'heading');
+        $temp = array('show_heading' => '', 'heading' => '');
+        $data = array(
+            array('show_heading' => '', 'heading' => ''),
+            array('show_heading' => '', 'heading' => ''),
+            array('show_heading' => '', 'heading' => ''),
+            array('show_heading' => '', 'heading' => ''),
+            array('show_heading' => '', 'heading' => ''),
+            array('show_heading' => '', 'heading' => ''),
+            array('show_heading' => '1', 'heading' => 'bar')
+        );
+        $pd_router = new XH_PageDataRouter($h, $fields, $temp, $data);
         $cf['show_hidden']['pages_search'] == 'true';
+        runkit_function_add(
+            'Pageparams_replaceAlternativeHeading',
+            function ($content, $pageData) {
+                if ($pageData['show_heading']) {
+                    $content = "<h1>{$pageData['heading']}</h1>";
+                }
+                return $content;
+            }
+        );
+    }
+
+    public function tearDown()
+    {
+        runkit_function_remove('Pageparams_replaceAlternativeHeading');
     }
 
     public function dataForSearch()
@@ -59,6 +87,10 @@ class SearchTest extends PHPUnit_Framework_TestCase
             array( // testing unicode equivalence
                 "sen\xCC\x83or",
                 method_exists('Normalizer', 'normalize') ? array(5) : array()
+            ),
+            array( // alternative heading
+                'bar',
+                array(6)
             )
         );
     }


### PR DESCRIPTION
page_params replaces the alternative heading only for the current page,
so the search functionality completely ignores the alternative headings
except for the first page. Replacing all page headings for each request
would be wasteful, so we factor out
Pageparams_replaceAlternativeHeading(), and use it from XH_Search, if
it's available. This introduces a soft core dependency on page_params,
but we prefer that over adding a respective function to the core which
would only be useful for page_params, and we keep in mind that we will
want to integrate at least parts of page_params into the core, anyway.