### PR TITLE
Close #135: add rel=nofollow to loginlink() and printlink()

### DIFF
--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -302,7 +302,8 @@ function printlink()
 {
     global $tx;
 
-    return '<a href="' . XH_printUrl() . '">' . $tx['menu']['print'] . '</a>';
+    return '<a href="' . XH_printUrl() . '" rel="nofollow">'
+        . $tx['menu']['print'] . '</a>';
 }
 
 /**
@@ -364,7 +365,8 @@ function loginlink()
     global $s, $tx;
 
     if (!XH_ADM) {
-        return a($s > -1 ? $s : 0, '&amp;login') . $tx['menu']['login'] . '</a>';
+        return a($s > -1 ? $s : 0, '&amp;login" rel="nofollow')
+            . $tx['menu']['login'] . '</a>';
     }
 }
 


### PR DESCRIPTION
We add rel=nofollow attributes to the login and print links, to
somewhat reduce the traffic caused by crawlers.