### PR TITLE
Close #36: Login Form detached from Template

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -1371,8 +1371,8 @@ $_XH_controller->sendStandardHeaders();
 
 if ($print) {
     XH_builtinTemplate('print');
-    //} elseif (strtolower($f) == 'login' || $f == 'forgotten') {
-    //    XH_builtinTemplate('xh_login');
+} elseif (strtolower($f) == 'login' || $f == 'forgotten') {
+    XH_builtinTemplate('xh_login');
 }
 
 if (XH_ADM) {


### PR DESCRIPTION
We present the login in the minimal built-in template, mainly to help
to login to a site which is in maintenance mode having a possibly
broken template.