### PR TITLE
Close #116: SystemCheck to state present state

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -274,6 +274,7 @@
 
 #xh_system_check {
     list-style: none;
+    padding-left: 0;
 }
 
 #xh_system_check li {

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -261,22 +261,25 @@ $tx['settings']['warning']="Bitte hier nur solche Änderungen durchführen, bei 
 
 $tx['submenu']['heading']="weiter zu:";
 
-$tx['syscheck']['access_protected']="'%s' zugriffsgeschützt";
-$tx['syscheck']['bom']="Ohne <a href=\"http://www.cmsimple-xh.org/wiki/doku.php/de:utf8#was_ist_ein_bom\" target=\"_blank\">BOM</a>";
-$tx['syscheck']['encoding']="UTF-8-Kodierung eingestellt";
-$tx['syscheck']['extension']="Erweiterung '%s' geladen";
+$tx['syscheck']['access_protected']="'%s' zugriffsgeschützt ist";
+$tx['syscheck']['bom']="kein <a href=\"http://www.cmsimple-xh.org/wiki/doku.php/de:utf8#was_ist_ein_bom\" target=\"_blank\">BOM</a> vorhanden ist";
+$tx['syscheck']['extension']="die Erweiterung '%s' geladen ist";
 $tx['syscheck']['fail']="Fehler";
-$tx['syscheck']['fsockopen']="Funktion fsockopen verfügbar";
-$tx['syscheck']['locale_available']="Locale '%s' verfügbar";
-$tx['syscheck']['locale_default']="Standard-Locale aktiv";
-$tx['syscheck']['magic_quotes']="'Magic quotes runtime' aus";
-$tx['syscheck']['password']="Voreingestelltes Passwort geändert";
-$tx['syscheck']['phpversion']="PHP-Version ≥ %s";
+$tx['syscheck']['fsockopen']="die Funktion fsockopen verfügbar ist";
+$tx['syscheck']['locale_available']="Locale '%s' verfügbar ist";
+$tx['syscheck']['locale_default']="das Standard-Locale aktiv ist";
+$tx['syscheck']['magic_quotes']="magic_quotes_runtime deaktiviert ist";
+$tx['syscheck']['message']="Prüfe, dass %1\$s … %2\$s";
+$tx['syscheck']['password']="das voreingestellte Passwort geändert wurde";
+$tx['syscheck']['phpversion']="die PHP-Version ≥ %s";
+$tx['syscheck']['safe_mode']="safe_mode deaktiviert ist";
 $tx['syscheck']['success']="OK";
-$tx['syscheck']['timezone']="Zeitzone gültig";
+$tx['syscheck']['timezone']="die Zeitzone gültig ist";
 $tx['syscheck']['title']="System-Prüfung";
+$tx['syscheck']['use_only_cookies']="session.use_only_cookies deaktiviert ist";
+$tx['syscheck']['use_trans_sid']="session.use_trans_sid deaktiviert ist";
 $tx['syscheck']['warning']="Warnung";
-$tx['syscheck']['writable']="'%s' schreibbar";
+$tx['syscheck']['writable']="'%s' schreibbar ist";
 
 $tx['sysinfo']['helplinks']="Hilfe und Informationen";
 $tx['sysinfo']['php_version']="PHP-Version";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -260,22 +260,25 @@ $tx['settings']['warning']="Only change settings when you understand the effect 
 
 $tx['submenu']['heading']="Submenu";
 
-$tx['syscheck']['access_protected']="'%s' access protected";
-$tx['syscheck']['bom']="Without <a href=\"http://www.cmsimple-xh.org/wiki/doku.php/utf8#what_s_a_bom\" target=\"_blank\">BOM</a>";
-$tx['syscheck']['encoding']="Encoding 'UTF-8' configured";
-$tx['syscheck']['extension']="Extension '%s' loaded";
-$tx['syscheck']['fail']="Failure";
-$tx['syscheck']['fsockopen']="Function fsockopen available";
-$tx['syscheck']['locale_available']="Locale '%s' available";
-$tx['syscheck']['locale_default']="Default locale in use";
-$tx['syscheck']['magic_quotes']="Magic quotes runtime off";
-$tx['syscheck']['password']="Non-default password set";
+$tx['syscheck']['access_protected']="'%s' is access protected";
+$tx['syscheck']['bom']="there is no <a href=\"http://www.cmsimple-xh.org/wiki/doku.php/utf8#what_s_a_bom\" target=\"_blank\">BOM</a>";
+$tx['syscheck']['extension']="extension '%s' is loaded";
+$tx['syscheck']['fail']="failure";
+$tx['syscheck']['fsockopen']="function fsockopen is available";
+$tx['syscheck']['locale_available']="locale '%s' is available";
+$tx['syscheck']['locale_default']="default locale is in use";
+$tx['syscheck']['magic_quotes']="magic_quotes_runtime is off";
+$tx['syscheck']['message']="Checking that %1\$s … %2\$s";
+$tx['syscheck']['password']="non-default password is set";
 $tx['syscheck']['phpversion']="PHP version ≥ %s";
-$tx['syscheck']['success']="OK";
-$tx['syscheck']['timezone']="Time zone valid";
+$tx['syscheck']['safe_mode']="safe_mode is off";
+$tx['syscheck']['success']="okay";
+$tx['syscheck']['timezone']="time zone is valid";
 $tx['syscheck']['title']="System check";
-$tx['syscheck']['warning']="Warning";
-$tx['syscheck']['writable']="'%s' writable";
+$tx['syscheck']['use_only_cookies']="session.use_only_cookies is off";
+$tx['syscheck']['use_trans_sid']="session.use_trans_sid is off";
+$tx['syscheck']['warning']="warning";
+$tx['syscheck']['writable']="'%s' is writable";
 
 $tx['sysinfo']['helplinks']="Info and Help Links";
 $tx['sysinfo']['php_version']="PHP-Version";


### PR DESCRIPTION
We don't actually change the system check to state the present state,
but rather rework it to make it clear that we're checking for a desired
or required condition, and whether that check succeeded, failed or
raised a warning. This way we can also get rid of the explicit <img>
elements, and instead re-use the respective core classes. We also
refactor a bit.