### PR TITLE
Close #126: add breadcrumb markup for locator

### DIFF
--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -403,20 +403,26 @@ function lastupdate($br = null, $hour = null)
  */
 function locator()
 {
-    $html = '';
     $breadcrumbs = XH_getLocatorModel();
     $last = count($breadcrumbs) - 1;
+    $html = '<span vocab="http://schema.org/" typeof="BreadcrumbList">';
     foreach ($breadcrumbs as $i => $breadcrumb) {
         list($title, $url) = $breadcrumb;
         if ($i > 0) {
             $html .= ' &gt; ';
         }
+        $html .= '<span property="itemListElement" typeof="ListItem">';
+        $inner = '<span property="name">' . $title
+            . '</span><meta property="position" content="'. ($i + 1) . '">';
         if (isset($url) && $i < $last) {
-            $html .= '<a href="' . $url . '">' . $title . '</a>';
+            $html .= '<a property="item" typeof="WebPage" href="' . $url . '">'
+                . $inner . '</a>';
         } else {
-            $html .= $title;
+            $html .= $inner;
         }
+        $html .= '</span>';
     }
+    $html .= '</span>';
     return $html;
 }
 

--- a/tests/unit/LocatorTest.php
+++ b/tests/unit/LocatorTest.php
@@ -53,7 +53,13 @@ class LocatorTest extends PHPUnit_Framework_TestCase
 
     public function testLocator()
     {
-        $this->assertEquals('<a href="?foo">Home</a> &gt; Bar', locator());
+        $expected = '<span vocab="http://schema.org/" typeof="BreadcrumbList">'
+            . '<span property="itemListElement" typeof="ListItem">'
+            . '<a property="item" typeof="WebPage" href="?foo">'
+            . '<span property="name">Home</span><meta property="position" content="1">'
+            . '</a></span> &gt; <span property="itemListElement" typeof="ListItem">'
+            . '<span property="name">Bar</span><meta property="position" content="2"></span></span>';
+        $this->assertEquals($expected, locator());
     }
 }
 


### PR DESCRIPTION
We're chosing RDFa Lite (which is simple to understand and a W3C
recommendation) with vocabulary from schema.org (which is the de-facto
standard). We apply only the most minimal markup changes, i.e. we don't
transform the locator to an <ol>, but rather insert <span>s as needed.