### PR TITLE
Close #63: Improving searchbox()

### DIFF
--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -269,14 +269,14 @@ function searchbox()
 {
     global $sn, $tx;
 
-    return '<form action="' . $sn . '" method="get">' . "\n"
-        . '<div id="searchbox">' . "\n"
-        . '<input type="text" class="text" name="search" title="'
-        . $tx['search']['label'] . '" size="12">' . "\n"
+    return '<form id="searchbox" action="' . $sn . '" method="get">' . "\n"
+        . '<input type="search" class="text" name="search" title="'
+        . $tx['search']['label'] . '" placeholder="' . $tx['search']['label']
+        . '" size="12">' . "\n"
         . '<input type="hidden" name="function" value="search">' . "\n" . ' '
         . '<input type="submit" class="submit" value="'
         . $tx['search']['button'] . '">' . "\n"
-        . '</div>' . "\n" . '</form>' . "\n";
+        . '</form>' . "\n";
 }
 
 

--- a/tests/unit/TplfuncsTest.php
+++ b/tests/unit/TplfuncsTest.php
@@ -74,12 +74,9 @@ class TplfuncsTest extends PHPUnit_Framework_TestCase
     public function testSearchbox()
     {
         $matcher = array(
-            'tag' => 'div',
+            'tag' => 'form',
             'id' => 'searchbox',
-            'parent' => array(
-                'tag' => 'form',
-                'attributes' => array('method' => 'get')
-            )
+            'attributes' => array('method' => 'get')
         );
         $actual = searchbox();
         @$this->assertTag($matcher, $actual);


### PR DESCRIPTION
We add a `placeholder` attribute (same value as the title), change the
`<input>`'s type to `search` and remove the superfluous `<div>`.