### PR TITLE
Close #141: place template stylesheet at the end

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -1132,12 +1132,6 @@ foreach (XH_plugins() as $plugin) {
 }
 
 /*
- * Add LINK to combined plugin stylesheet.
- */
-$hjs .= '<link rel="stylesheet" href="' . XH_pluginStylesheet()
-    . '" type="text/css">' . PHP_EOL;
-
-/*
  * Include index.php of all plugins.
  */
 foreach (XH_plugins() as $plugin) {

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -89,6 +89,8 @@ function head()
         . XH_renderPrevLink() . XH_renderNextLink()
         . '<link rel="stylesheet" href="' . $pth['file']['corestyle']
         . '" type="text/css">' . "\n"
+        . '<link rel="stylesheet" href="' . XH_pluginStylesheet()
+        . '" type="text/css">' . PHP_EOL
         . '<link rel="stylesheet" href="' . $pth['file']['stylesheet']
         . '" type="text/css">' . "\n"
         . $hjs;

--- a/tests/unit/HeadTest.php
+++ b/tests/unit/HeadTest.php
@@ -44,6 +44,13 @@ class HeadTest extends PHPUnit_Framework_TestCase
     protected $pluginsMock;
 
     /**
+     * The XH_pluginStylesheet() mock.
+     *
+     * @var object
+     */
+    protected $pluginStylesheetMock;
+
+    /**
      * Sets up the test fixture.
      *
      * @return void
@@ -74,6 +81,8 @@ class HeadTest extends PHPUnit_Framework_TestCase
         $this->titleMock = new PHPUnit_Extensions_MockFunction('XH_title', null);
         $this->pluginsMock = new PHPUnit_Extensions_MockFunction('XH_plugins', null);
         $this->pluginsMock->expects($this->any())->will($this->returnValue(array()));
+        $this->pluginStylesheetMock = new PHPUnit_Extensions_MockFunction('XH_pluginStylesheet', null);
+        $this->pluginStylesheetMock->expects($this->once());
     }
 
     /**
@@ -85,6 +94,7 @@ class HeadTest extends PHPUnit_Framework_TestCase
     {
         $this->titleMock->restore();
         $this->pluginsMock->restore();
+        $this->pluginStylesheetMock->restore();
     }
 
     /**


### PR DESCRIPTION
It makes sense to link the template stylesheet after the plugin
stylesheets, so that the template has the last word (without refraining
to !important or specificity trickery). This also would be helpful with
regard to #140, because at least combining core.css and plugins.css
could easily be done without any issues regarding language or even page
specific templates.

Technically, this constitutes a BC break, but we don't think there are
too many issue in practice.