### PR TITLE
Close #137: robots="noindex" for search result

### DIFF
--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -211,13 +211,15 @@ class Search
      * @global array  The headings of the pages.
      * @global array  The URLs of the pages.
      * @global string The script name.
+     * @global array  The configuration of the core.
      * @global array  The localization of the core.
      * @global object The page data router.
      */
     public function render()
     {
-        global $h, $u, $sn, $tx, $pd_router;
+        global $h, $u, $sn, $cf, $tx, $pd_router;
 
+        $cf['meta']['robots'] = 'noindex, nofollow';
         $o = '<h1>' . $tx['search']['result'] . '</h1>';
         $words = $this->getWords();
         $pages = $this->search();


### PR DESCRIPTION
It doesn't make sense to let search engines index any search results,
because of potential DC issues. It also doesn't make sense to let them
follow the linked results, because these also generate DC due to the
`search` parameter which is used for highlighting the search terms.