### PR TITLE
Close #139: PHP 7 changes parse error handling of eval() & co.

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -149,7 +149,11 @@ function evaluate_cmsimple_scripting($__text, $__compat = true)
         foreach ($__scripts[1] as $__script) {
             if (!in_array(strtolower($__script), array('hide', 'remove'))) {
                 $__script = html_entity_decode($__script, ENT_QUOTES, 'UTF-8');
-                eval($__script);
+                try {
+                    eval($__script);
+                } catch (ParseError $ex) {
+                    trigger_error('Parse error: ' . $ex->getMessage(), E_USER_WARNING);
+                }
                 if ($__compat) {
                     break;
                 }
@@ -206,9 +210,14 @@ function evaluate_plugincall($text)
         );
         $function = $call[1][0];
         if (function_exists($function)) {
-            $results[] = XH_evaluateSinglePluginCall(
-                $function . '(' . $arguments . ')'
-            );
+            try {
+                $results[] = XH_evaluateSinglePluginCall(
+                    $function . '(' . $arguments . ')'
+                );
+            } catch (ParseError $ex) {
+                $results[] = '';
+                trigger_error('Parse error: ' . $ex->getMessage(), E_USER_WARNING);
+            }
         } else {
             $results[] = sprintf($message, $function);
         }

--- a/tests/unit/ScriptEvaluationTest.php
+++ b/tests/unit/ScriptEvaluationTest.php
@@ -92,6 +92,15 @@ class ScriptEvaluationTest extends PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('keywords', $GLOBALS);
     }
 
+    public function testEvaluateCmsimpleScriptingParseError()
+    {
+        if (PHP_MAJOR_VERSION !== 5) {
+            $this->markTestSkipped();
+        }
+        $this->expectOutputRegex('/^\s*Parse error:/s');
+        evaluate_cmsimple_scripting('#CMSimple trim(\');#');
+    }
+
     /**
      * @dataProvider dataForSpliceString
      */
@@ -155,6 +164,15 @@ class ScriptEvaluationTest extends PHPUnit_Framework_TestCase
         $actual = evaluate_plugincall($str, true);
         $this->assertEquals($expected, $actual);
         $this->assertFalse(isset($GLOBALS['keywords']));
+    }
+
+    public function testEvaluatePluginCallParseError()
+    {
+        if (PHP_MAJOR_VERSION !== 5) {
+            $this->markTestSkipped();
+        }
+        $this->expectOutputRegex('/^\s*Parse error:/s');
+        evaluate_plugincall('{{{trim(\')}}}');
     }
 }
 


### PR DESCRIPTION
As of PHP 7.0.0 parse errors in `eval()` are propagated to the calling
script, so we have to catch the `ParseError` to avoid a white screen of
death; instead we raise a USER_WARNING. Under PHP 5 everything stays as
it was.