### PR TITLE
Close #124: Missing Normalize Class

### DIFF
--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -90,7 +90,7 @@ class Search
             foreach ($words as $word) {
                 $word = trim($word);
                 if ($word != '') {
-                    if (class_exists('\Normalizer') 
+                    if (class_exists('\Normalizer', false) 
                         && method_exists('\Normalizer', 'normalize')
                     ) {
                         $word = \Normalizer::normalize($word);


### PR DESCRIPTION
There is actually no need to trigger the autoloader if the class
`Normalizer` is not defined, because the class is built-in (or not),
and we don't provide a fallback, anyway.