### PR TITLE
Close #133: Add check for "secure" password

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -1122,6 +1122,7 @@ function XH_adminJSLocalization()
     $keys = array(
         'action' => array('advanced_hide', 'advanced_show', 'cancel', 'ok'),
         'error' => array('server'),
+        'password' => array('score'),
         'settings' => array('backupsuffix')
     );
     $l10n = array();

--- a/cmsimple/classes/ChangePassword.php
+++ b/cmsimple/classes/ChangePassword.php
@@ -137,14 +137,18 @@ class ChangePassword
     protected function renderField($which, $value)
     {
         $id = "xh_password_$which";
-        return '<p>'
+        $html = '<p>'
             . '<label for="' . $id . '">' . $this->lang['password'][$which]
             . '</label> '
             . tag(
                 'input id="' . $id . '" type="password" name="' . $id
                 . '" value="' . XH_hsc($value) . '"'
-            )
-            . '</p>';
+            );
+        if (in_array($which, array('old', 'new'))) {
+            $html .= ' <span class="xh_password_score"></span>';
+        }
+        $html .= '</p>';
+        return $html;
     }
 
     /**

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -232,6 +232,7 @@ $tx['password']['invalid']="Das neue Passwort darf nur aus ASCII-Zeichen bestehe
 $tx['password']['mismatch']="Das neue Passwort stimmt nicht mit der Bestätigung überein.";
 $tx['password']['new']="Neues Passwort";
 $tx['password']['old']="Altes Passwort";
+$tx['password']['score']="Passwortstärke: %s";
 $tx['password']['wrong']="Das alte Passwort ist falsch.";
 
 $tx['password_forgotten']['email1_sent']="Eine E-Mail mit einem Link zum Zurücksetzen des Passworts wurde an die hinterlegte Adresse verschickt. Dieser Link ist für 1-2 Stunden gültig.";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -231,6 +231,7 @@ $tx['password']['invalid']="New password must consist of ASCII characters only."
 $tx['password']['mismatch']="New password and its confirmation do not match.";
 $tx['password']['new']="New password";
 $tx['password']['old']="Old password";
+$tx['password']['score']="Password score: %s";
 $tx['password']['wrong']="Old password is wrong.";
 
 $tx['password_forgotten']['email1_sent']="An email has been sent to the configured address with a link to reset the password. This link is valid for 1-2 hours.";


### PR DESCRIPTION
We compute and display the score of passwords immediately while they
are entered in the change password screen, because that appears to make
the most sense, as users can improve the password right away, instead
of checking the password score in the system check and changing the
password again if necessary. We also compute and display the password
score of the old password for reference (particularly interesting wrt.
default password).

We display the password score in a simple textual form instead of a
fancy password strength meter for accessibility and simplicity.

The algorithm to calculate the password score was taken from
http://stackoverflow.com/questions/948172/password-strength-meter#11268104
with minor improvements. It is very simplistic, but appears to yield
sensible results, e.g. scores > 100 indicate very strong passwords. The
algorithm works properly for ASCII characters only, but our passwords
are limited to a subset of ASCII anyway, so that's fine.