### PR TITLE
Close #71: Rename Settings → CMS

### DIFF
--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -31,7 +31,7 @@ $tx['action']['view']="ansehen";
 
 $tx['editmenu']['backups']="Sicherheitskopien";
 $tx['editmenu']['change_password']="Passwort";
-$tx['editmenu']['configuration']="CMS";
+$tx['editmenu']['configuration']="Konfiguration";
 $tx['editmenu']['downloads']="Downloads";
 $tx['editmenu']['edit']="Bearbeiten";
 $tx['editmenu']['files']="Dateien";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -31,7 +31,7 @@ $tx['action']['view']="view";
 
 $tx['editmenu']['backups']="Backups";
 $tx['editmenu']['change_password']="Password";
-$tx['editmenu']['configuration']="CMS";
+$tx['editmenu']['configuration']="Configuration";
 $tx['editmenu']['downloads']="Downloads";
 $tx['editmenu']['edit']="Edit mode";
 $tx['editmenu']['files']="Files";


### PR DESCRIPTION
For consistency we rename Settings → CMS to Settings → Configuration.