### PR TITLE
Close #125: Internationalize date representations

### DIFF
--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -48,5 +48,7 @@ $cf['title']['format']="{SITE} &ndash; {PAGE}";
 $cf['headings']['show']="true";
 $cf['headings']['format']="<h1>%s</h1>";
 $cf['mode']['advanced']="";
+$cf['format']['date']="long";
+$cf['format']['time']="short";
 
 ?>

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2503,20 +2503,29 @@ function XH_onShutdown()
     }
 }
 /**
- * Returns a timestamp formatted according to <var>$tx[lastupdate][dateformat]</var>.
+ * Returns a timestamp formatted according to config and lang.
  *
  * @param int $timestamp A UNIX timestamp.
  *
  * @return string
  *
+ * @global array The configuration of the core.
  * @global array The localization of the core.
  *
  * @since 1.6.3
  */
 function XH_formatDate($timestamp)
 {
-    global $tx;
+    global $cf, $tx;
 
+    if (class_exists('IntlDateFormatter', false)) {
+        $dateFormatter = new IntlDateFormatter(
+            $tx['locale']['all'] ? $tx['locale']['all'] : null,
+            constant('IntlDateFormatter::' . strtoupper($cf['format']['date'])),
+            constant('IntlDateFormatter::' . strtoupper($cf['format']['time']))
+        );
+        return $dateFormatter->format($timestamp);
+    }
     return date($tx['lastupdate']['dateformat'], $timestamp);
 }
 

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -136,6 +136,9 @@ $tx['help']['folders_downloads']="Ein Unterordner der Benutzerdateien.";
 $tx['help']['folders_images']="Ein Unterordner der Benutzerdateien.";
 $tx['help']['folders_media']="Ein Unterordner der Benutzerdateien.";
 
+$tx['help']['format_date']="Das Datumsformat, wenn ext/intl verfügbar ist; andernfalls wird auf <code>\$tx['lastupdate']['format']</code> zurückgegriffen.";
+$tx['help']['format_time']="Das Zeitformat, wenn ext/intl verfügbar ist; andernfalls wird auf <code>\$tx['lastupdate']['format']</code> zurückgegriffen.";
+
 $tx['label']['empty']="- LEER -";
 
 $tx['languagemenu']['text']="Sprachauswahl: ";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -135,6 +135,9 @@ $tx['help']['folders_downloads']="A subfolder of userfiles.";
 $tx['help']['folders_images']="A subfolder of userfiles.";
 $tx['help']['folders_media']="A subfolder of userfiles.";
 
+$tx['help']['format_date']="The date format if ext/intl is available; otherwise the date/time format falls back to <code>\$tx['lastupdate']['format']</code>.";
+$tx['help']['format_time']="The time format if ext/intl is available; otherwise the date/time format falls back to <code>\$tx['lastupdate']['format']</code>.";
+
 $tx['label']['empty']="- EMPTY -";
 
 $tx['languagemenu']['text']="select language: ";

--- a/cmsimple/metaconfig.php
+++ b/cmsimple/metaconfig.php
@@ -33,5 +33,7 @@ $mcf['editmenu']['scroll']="bool";
 $mcf['editmenu']['external']="xfunction:XH_registeredEditmenuPlugins";
 $mcf['headings']['show']="bool";
 $mcf['mode']['advanced']="bool";
+$mcf['format']['date']="enum:none,short,medium,long,full";
+$mcf['format']['time']="enum:none,short,medium,long,full";
 
 ?>

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -690,7 +690,16 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
      */
     public function testFormatDate()
     {
-        $this->assertEquals('January 02, 1970, 11:17', XH_formatDate('123456'));
+        global $tx;
+
+        if (class_exists('IntlDateFormatter', false)) {
+            $oldLocale = $tx['locale']['all'];
+            $tx['locale']['all'] = 'en_US';
+            $this->assertEquals('January 2, 1970 at 11:17 AM', XH_formatDate('123456'));
+            $tx['locale']['all'] = $oldLocale;
+        } else {
+            $this->assertEquals('January 02, 1970, 11:17', XH_formatDate('123456'));
+        }
     }
 
     /**


### PR DESCRIPTION
If class `IntlDateFormatter` is available, we use it to format date/times
in `XH_formatDate()`; otherwise we fall back to the old solution using
`$tx['lastupdate']['format']`.

The advantage of `IntlDateFormatter` over `strftime()` is that ICU has
its own locale support, so it's not necessary to have the locales
actually installed, and `setlocale()` has issues in multi-threaded
environments anyway.