### PR TITLE
Close #180: Missing backlink on login page

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1586,6 +1586,8 @@ function loginforms()
             $o .= '<a href="' . $sn . '?&function=forgotten">'
                 . $tx['title']['password_forgotten'] . '</a>';
         }
+        $o .= '<p><a href="' . "$sn?$su" . '">' . $tx['login']['back']
+            . '</a></p>';
         $o .= ' </div>';
         $s = -1;
     }

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -176,6 +176,7 @@ $tx['log']['module']="Modul";
 $tx['log']['category']="Kategorie";
 $tx['log']['description']="Beschreibung";
 
+$tx['login']['back']="Zurück";
 $tx['login']['failure']="Sie haben ein falsches Passwort eingegeben!";
 $tx['login']['loggedout']="Sie wurden ausgeloggt";
 $tx['login']['warning']="Administrationsbereich. Bitte Passwort eingeben";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -175,6 +175,7 @@ $tx['log']['module']="module";
 $tx['log']['category']="category";
 $tx['log']['description']="description";
 
+$tx['login']['back']="Back";
 $tx['login']['failure']="You have entered a wrong password!";
 $tx['login']['loggedout']="You have been logged out";
 $tx['login']['warning']="Site administration. Please enter password.";


### PR DESCRIPTION
As the login is detached from the template as of commit bd0a68e,
visitors inadvertently clicking the login link might be lost, so we add
a back link below the login form.