### PR TITLE
Close #181: Remove PHP 4 fallbacks

### DIFF
--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -164,15 +164,7 @@ class Search
         if (method_exists('\Normalizer', 'normalize')) {
             $content = \Normalizer::normalize($content);
         }
-        // html_entity_decode() doesn't work for UTF-8 under PHP 4
-        $decode = array(
-            '&amp;' => '&',
-            '&quot;' => '"',
-            '&apos;' => '\'',
-            '&lt;' => '<',
-            '&gt;' => '>'
-        );
-        return strtr($content, $decode);
+        return html_entity_decode($content, ENT_QUOTES, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
As we require PHP 5.3.0 at least, there's no need for PHP 4 fallbacks
anymore.