### PR TITLE
Close #182: Separate page names from the content

### DIFF
--- a/2lang/content/content.htm
+++ b/2lang/content/content.htm
@@ -1,6 +1,6 @@
 <html><head><title>Content-Datei</title>
 <?php
-$page_data_fields=array('url','last_edit','description','keywords','title','robots','heading','show_heading','template','published','show_last_edit','linked_to_menu','header_location','use_header_location','publication_date','expires');
+$page_data_fields=array('url','last_edit','description','keywords','title','robots','template','published','show_last_edit','linked_to_menu','header_location','use_header_location','publication_date','expires');
 $temp_data=array(
 'url'=>'Startseite',
 'last_edit'=>'1251465256',
@@ -8,8 +8,6 @@ $temp_data=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -26,8 +24,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -38,6 +34,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h1>Welcome to CMSimple_XH</h1>
 <p>Congratulations on your new <strong>Language</strong> installation of CMSimple_XH.</p>
 <p>You can login with the <strong>password of your main site</strong>. You will find the login link at the bottom of the page in the footer.</p>
 <p>Please read about file permissions and security issues in the <a href="http://www.cmsimple-xh.org/wiki/doku.php/installation">CMSimple_XH Wiki »</a></p>
@@ -64,8 +61,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -93,8 +88,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -122,8 +115,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',

--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -155,10 +155,6 @@ class Search
         global $cf, $s, $h;
 
         $s = $pageIndex;
-        // we have to add the page heading, if visible in content
-        if ($cf['headings']['show']) {
-            $content = $h[$s] . $content;
-        }
         $content = strip_tags(evaluate_plugincall($content));
         $s = -1;
         if (method_exists('\Normalizer', 'normalize')) {

--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -152,7 +152,7 @@ class Search
      */
     protected function prepareContent($content, $pageIndex)
     {
-        global $cf, $s, $h;
+        global $s;
 
         $s = $pageIndex;
         $content = strip_tags(evaluate_plugincall($content));

--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -45,6 +45,6 @@ $cf['uri']['length']="200";
 $cf['editmenu']['scroll']="";
 $cf['editmenu']['external']="";
 $cf['title']['format']="{SITE} &ndash; {PAGE}";
-$cf['mode']['advanced']="true";
+$cf['mode']['advanced']="";
 
 ?>

--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -1,7 +1,7 @@
 <?php
 
 $cf['security']['password']="\$2a\$09\$b032aima.KOrfY.N6ex44esuEon1K8WP/QjeTeaAc0Kmhw6NOl/2u";
-$cf['security']['secret']="5b2b98208d4fc6ce9331e47d";
+$cf['security']['secret']="cf7c3ecb0495698c7f657d65";
 $cf['security']['email']="";
 $cf['security']['frame_options']="";
 $cf['site']['template']="mini1";
@@ -45,8 +45,6 @@ $cf['uri']['length']="200";
 $cf['editmenu']['scroll']="";
 $cf['editmenu']['external']="";
 $cf['title']['format']="{SITE} &ndash; {PAGE}";
-$cf['headings']['show']="true";
-$cf['headings']['format']="<h1>%s</h1>";
-$cf['mode']['advanced']="";
+$cf['mode']['advanced']="true";
 
 ?>

--- a/cmsimple/metaconfig.php
+++ b/cmsimple/metaconfig.php
@@ -31,7 +31,6 @@ $mcf['menu']['sdoc']="enum:,parent";
 $mcf['uri']['length']="hidden";
 $mcf['editmenu']['scroll']="bool";
 $mcf['editmenu']['external']="xfunction:XH_registeredEditmenuPlugins";
-$mcf['headings']['show']="bool";
 $mcf['mode']['advanced']="bool";
 
 ?>

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -452,16 +452,14 @@ function editmenu()
  *
  * @return string HTML
  *
- * @global array  The headings of the pages.
  * @global int    The index of the current page.
  * @global string The output of the contents area.
  * @global array  The content of the pages.
  * @global bool   Whether edit mode is active.
- * @global array  The configuration of the core.
  */
 function content()
 {
-    global $h, $s, $o, $c, $edit, $cf;
+    global $s, $o, $c, $edit;
     $heading = '';
 
     if (!($edit && XH_ADM) && $s > -1) {

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -464,11 +464,6 @@ function content()
     global $h, $s, $o, $c, $edit, $cf;
     $heading = '';
 
-    if ($cf['headings']['show'] && $s > -1) {
-        if (preg_match('/<!--XH_ml[1-9]:(.+)-->/isU', $c[$s], $matches)) {
-            $heading = sprintf($cf['headings']['format'], $matches[1]);
-        } 
-    }
     if (!($edit && XH_ADM) && $s > -1) {
         if (isset($_GET['search'])) {
             $search = XH_hsc(stsl($_GET['search']));
@@ -479,9 +474,6 @@ function content()
         $o .= $heading . preg_replace('/#CMSimple (.*?)#/is', '', $c[$s]);
         return  preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $o);
     } else {
-        if ($s > -1 && ($cf['headings']['show'] || ($edit && XH_ADM))) {
-            $o = sprintf($cf['headings']['format'], $h[$s]) . $o;
-        }
         return  preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $o);
     }
 }

--- a/content/content.htm
+++ b/content/content.htm
@@ -1,6 +1,6 @@
 <html><head><title>Content file</title>
 <?php
-$page_data_fields=array('keywords','title','robots','heading','show_heading','template','published','show_last_edit','linked_to_menu','header_location','use_header_location','publication_date','expires','description');
+$page_data_fields=array('keywords','title','robots','template','published','show_last_edit','linked_to_menu','header_location','use_header_location','publication_date','expires','description');
 $temp_data=array(
 'url'=>'WebLog',
 'last_edit'=>'1322055182',
@@ -8,8 +8,6 @@ $temp_data=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -28,8 +26,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -40,6 +36,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h1>Welcome to CMSimple_XH</h1>
 <p>Congratulations on your new installation of CMSimple_XH. You can login now with the default password, which you will find in the readme.txt of the download. Delete the readme.txt on your webserver, if you have uploaded it.</p>
 <p>The login link can be found at the bottom of the page in the footer.</p>
 <div class="warning">
@@ -80,8 +77,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -92,6 +87,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h1>Menu Levels and Headings</h1>
 <p>HMTL provides 6 headings, h1-h6, from big to small. CMSimple_XH uses the bigger headings for splitting the content into webpages. It is like a book, where a big heading starts a new chapter. The remaining smaller headings are used as headings within the web page, just as in a book, where smaller headings are used within a chapter. The book itself is the unit containing the complete text, corresponding in CMSimple_XH to the content file. A chapter in the book corresponds to a web page.</p>
 <p>In Settings/CMS you can set the number of levels for your page menu navigation. Preset is 3, i.e. CMSimple_XH will use headings h1–h3 for splitting up the content file into web pages. Thus an h1, h2 or h3 heading will create a new web page in the table of contents. The remaining h4, h5 and h6 headings will not. They can be used as headings within a web page.</p>
 <p>If you set 4 levels, h4 also will be used for new web pages. If you set only 2 levels, h3 and h4 can be used as headings within a web page. However in most cases 3 levels is a good compromise.</p>
@@ -108,8 +104,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -120,6 +114,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>Menu Level 2 – Page 1</h2>
 <p>An h2 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -136,8 +131,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -148,6 +141,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 1</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -164,8 +158,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -176,6 +168,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 2</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -192,8 +185,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -204,6 +195,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 3</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -220,8 +212,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -232,6 +222,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>Menu Level 2 – Page 2</h2>
 <p>An h2 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -248,8 +239,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -260,6 +249,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 1</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -276,8 +266,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -288,6 +276,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 2</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -304,8 +293,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -316,6 +303,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 3</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -332,8 +320,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -344,6 +330,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 2 – Page 3</h3>
 <p>An h2 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -360,8 +347,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -372,6 +357,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 1</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -388,8 +374,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -400,6 +384,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 2</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -416,8 +401,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -428,6 +411,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h3>Menu Level 3 – Page 3</h3>
 <p>An h3 heading splits into a new page.</p>
 <h4>Heading h4</h4>
 <p>Headings h4–h6 do not split the content into new pages, but serve as normal headings to structure your text semantically.</p>
@@ -444,8 +428,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -456,6 +438,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h1>Templates and Plugins</h1>
 <p>Through the use of a different <strong>template</strong> you can give your pages a completely different look, and through <strong>plugins</strong> you can greatly enlarge the functionality of your CMSimple_XH website.</p>
 <div class="warning">
 <p>While installing templates or plugins, <br> please respect the licensing conditions of the authors.</p>
@@ -472,8 +455,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'gonzo-h',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -484,6 +465,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>gonzo-h</h2>
 <p>A template with a slightly responsive grid layout. Have a look at the accompanying <a href="http://www.web57.ws/cms/?Mein_CMSimple:Template_fuer_CMSimple_erstellen">template tutorial</a> or its <a href="http://www.cmsimple-xh.org/wiki/doku.php/template_tutorial">English translation</a>.</p>
 <p>This template was contributed by <a href="http://web57.ws/cms/">snafu</a> (<em>composite photo by svasti</em>).</p>
 <h4>Heading h4</h4>
@@ -510,8 +492,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -522,6 +502,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>mini1</h2>
 <p>A template with a fluid layout, a horizontal menu of the toplevel pages and a vertical menu of the subpages. This template is meant as starting point for the development of other templates. It was contributed by <a href="http://svasti.de">svasti</a>.</p>
 <p>The template has some format definitions, which can be applied via the "Formats" or "Styles" selection (designation depends on the editor). </p>
 <div class="warning">This is the paragraph format "warning".</div>
@@ -556,8 +537,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'n6200tbisGPL3',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -568,6 +547,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>n6200tbisGPL3</h2>
 <p>A responsive template with a horizontal mega menu and an additional vertical menu.<span> This template's stylesheet contains some invalid CSS declarations, which are necessary for compatibility with different browsers.</span></p>
 <p>This template was contributed by <a href="http://torsten-behrens.de/">Torsten.Behrens</a>. Check out his website for more templates.</p>
 <h4>Heading h4</h4>
@@ -594,8 +574,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'photo11',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -606,6 +584,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>photo11</h2>
 <p>A template with fixed width table layout already prepared for 5 newsboxes.</p>
 <p>This template was contributed by <a href="http://www.cmsimple.pw/">mikey</a>.</p>
 <h4>Heading h4</h4>
@@ -632,8 +611,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'praia',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -644,6 +621,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>praia</h2>
 <p>A fixed width template suitable for a small number of toplevel pages only. This template's stylesheet contains some invalid CSS declarations, which are necessary for compatibility with different browsers.</p>
 <p>This template was contributed by <a href="http://3-magi.net/">cmb</a>.</p>
 <h4>Heading h4</h4>
@@ -670,8 +648,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'responsivehtml',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -682,6 +658,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>responsivehtml</h2>
 <p>A responsive template with a vertical menu that collapses on small screens.</p>
 <p>This template was contributed by <a href="http://oldnema.compsys.cz/en/?Demo_templates">oldnema</a>. Check out his website for more templates.</p>
 <h4>Heading h4</h4>
@@ -708,8 +685,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'structure1_black',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -720,6 +695,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h2>structure1_black</h2>
 <p>A responsive template with a dark background. The horizontal menu shows only the toplevel pages; subpages can be accessed via the submenu below the page content.</p>
 <p>This template was contributed by <a href="http://cmsimple.sk/">Tata</a>.</p>
 <h4>Heading h4</h4>
@@ -746,8 +722,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'',
 'template'=>'',
 'published'=>'',
 'show_last_edit'=>'',
@@ -758,6 +732,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
+<h1>Languages</h1>
 <p>The standard download of CMSimple_XH from version 1.5 onwards comes with English and German language files only.</p>
 <p>Please don’t delete the "default" and "en" language files (default.php and en.php), as they serve as default fallback.</p>
 <p>German language files are included because the German language user’s community is by far the largest and practically all of the developer’s team is German speaking.</p>
@@ -771,8 +746,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -800,8 +773,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -829,8 +800,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -858,8 +827,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -887,8 +854,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',
@@ -915,8 +880,6 @@ $page_data[]=array(
 'keywords'=>'',
 'title'=>'',
 'robots'=>'',
-'heading'=>'',
-'show_heading'=>'0',
 'template'=>'0',
 'published'=>'1',
 'show_last_edit'=>'0',

--- a/plugins/page_params/Pageparams_view.php
+++ b/plugins/page_params/Pageparams_view.php
@@ -258,17 +258,6 @@ function Pageparams_view(array $page)
     $view .= "\n\t" . '<p><b>' . $lang['form_title'] . '</b></p>';
 
     /*
-     * heading
-     */
-    $view .= Pageparams_caption($lang['heading'], $lang['hint_heading']);
-    $view .= Pageparams_checkbox('show_heading', $page['show_heading'] == '1');
-    $view .= '<br>';
-    $view .= Pageparams_input(
-        'heading', $page['heading'], $page['show_heading'] !== '1'
-    );
-    $view .= '<br>' . "\n\t" . '<hr>';
-
-    /*
      * published
      */
     $view .= Pageparams_caption($lang['published'], $lang['hint_published']);

--- a/plugins/page_params/index.php
+++ b/plugins/page_params/index.php
@@ -139,8 +139,6 @@ function Pageparams_switchTemplate($n)
 /*
  * Add used interests to router.
  */
-$pd_router->add_interest('heading');
-$pd_router->add_interest('show_heading');
 $pd_router->add_interest('template');
 $pd_router->add_interest('published');
 $pd_router->add_interest('publication_date');
@@ -167,17 +165,6 @@ Pageparams_switchTemplate($pd_s);
  * Override defaults by page-parameters but only if not in edit-mode.
  */
 if (!$edit && $pd_current) {
-    if ($pd_current['show_heading'] == '1') {
-        $temp = '/(<!--XH_ml[1-9]:).+(-->)/isU';
-        if (trim($pd_current['heading']) == '') {
-            $c[$pd_s] = preg_replace($temp, '', $c[$pd_s]);
-        } else {
-            $c[$pd_s] = preg_replace(
-                $temp, '${1}' . addcslashes($pd_current['heading'], '$\\') . '$2',
-                $c[$pd_s]
-            );
-        }
-    }
     if ($pd_current['show_last_edit'] > 0
         && $pd_current['last_edit'] !== ''
     ) {

--- a/plugins/page_params/languages/de.php
+++ b/plugins/page_params/languages/de.php
@@ -2,7 +2,6 @@
 
 $plugin_tx['page_params']['tab']="Seite";
 $plugin_tx['page_params']['form_title']="Seiten-Parameter";
-$plugin_tx['page_params']['heading']="Andere Seitenüberschrift?";
 $plugin_tx['page_params']['header_location']="Seite umleiten?";
 $plugin_tx['page_params']['template']="Seitentemplate";
 $plugin_tx['page_params']['last_edit']="Letzte Bearbeitung:";

--- a/plugins/page_params/languages/en.php
+++ b/plugins/page_params/languages/en.php
@@ -2,7 +2,6 @@
 
 $plugin_tx['page_params']['tab']="Page";
 $plugin_tx['page_params']['form_title']="Page parameters";
-$plugin_tx['page_params']['heading']="Alternative heading?";
 $plugin_tx['page_params']['header_location']="Redirect page?";
 $plugin_tx['page_params']['template']="Page template:";
 $plugin_tx['page_params']['last_edit']="Last edited:";

--- a/plugins/page_params/pageparams.js
+++ b/plugins/page_params/pageparams.js
@@ -40,19 +40,6 @@
     }
 
     /**
-     * Handles show_heading click events.
-     *
-     * @param {Event} event
-     *
-     * @returns {undefined}
-     */
-    function onShowHeadingClick(event) {
-        var target = event.target || event.srcElement;
-
-        toggle(target.form.elements.heading);
-    }
-
-    /**
      * Handles published click events.
      *
      * @param {Event} event
@@ -139,7 +126,6 @@
         form = document.getElementById("page_params");
         if (form) {
             elements = form.elements;
-            on(elements.show_heading[1], "click", onShowHeadingClick);
             on(elements.published[1], "click", onPublishedClick);
             on(elements.publication_date, "change", onDateChange);
             on(elements.expires, "change", onDateChange);


### PR DESCRIPTION
We change $cf[headings][show] to false, and hard-code this in the code,
so that we can remove this config option. This makes $cf[headings]
[format] unused, so we remove it as well. We also can get rid of the
page data fields 'heading' and 'show_heading', as the heading of the
page is independent of the page name now.