### PR TITLE
Close #77: Partially integrate page_params into the core

### DIFF
--- a/cmsimple/classes/PageDataRouter.php
+++ b/cmsimple/classes/PageDataRouter.php
@@ -394,7 +394,7 @@ class PageDataRouter
      * @global string
      * @global string
      * @global string
-     * @global int    The index of the first published page.
+     * @global object The publisher.
      *
      * @return string HTML
      */
@@ -402,13 +402,13 @@ class PageDataRouter
     public function create_tabs($s)
     {
 // @codingStandardsIgnoreElse
-        global $edit, $f, $o, $su, $_XH_firstPublishedPage;
+        global $edit, $f, $o, $su, $xh_publisher;
 
         if (is_array($this->model->tabs)
             && count($this->model->tabs) > 0 && $edit
         ) {
             if ($s == -1 && !$f && $o == '' && $su == '') { // Argh! :(
-                $pd_s = $_XH_firstPublishedPage;
+                $pd_s = $xh_publisher->getFirstPublishedPage();
             } else {
                 $pd_s = $s;
             }

--- a/cmsimple/classes/Publisher.php
+++ b/cmsimple/classes/Publisher.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Publishing and hiding of pages.
+ *
+ * PHP version 5
+ *
+ * @category  CMSimple_XH
+ * @package   XH
+ * @author    Martin Damken <kontakt@zeichenkombinat.de>
+ * @author    Jerry Jakobsfeld <mail@simplesolutions.dk>
+ * @author    The CMSimple_XH developers <devs@cmsimple-xh.org>
+ * @copyright 2009-2016 The CMSimple_XH developers <http://cmsimple-xh.org/?The_Team>
+ * @license   http://www.gnu.org/licenses/gpl-3.0.en.html GNU GPLv3
+ * @link      http://cmsimple-xh.org/
+ */
+
+namespace XH;
+
+/**
+ * Reliable information about published and hidden pages.
+ *
+ * Publisher respects `#cmsimple hide#` and `#cmsimple remove#` as well as the
+ * page data fields `linked_to_menu`, `published`, `publication_date` and
+ * `expires`. Note that unpublishing via `#cmsimple remove#` cannot be detected
+ * by other means except for Publisher::isPublished(), because it is replaced
+ * during content loading. Also note that all pages are published and none is
+ * hidden in edit mode.
+ *
+ * @category CMSimple_XH
+ * @package  XH
+ * @author   The CMSimple_XH developers <devs@cmsimple-xh.org>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.en.html GNU GPLv3
+ * @link     http://cmsimple-xh.org/
+ * @since    1.7
+ */
+class Publisher
+{
+    /**
+     * The publishing status of the pages.
+     *
+     * @var bool[]
+     */
+    protected $published = array();
+
+    /**
+     * The hide status of the pages.
+     *
+     * @var bool[]
+     */
+    protected $hidden = array();
+
+    /**
+     * Initializes a new instance.
+     *
+     * @param bool[] $removed The removed status of the pages.
+     */
+    public function __construct(array $removed)
+    {
+        global $pd_router, $cl, $edit;
+
+        $pd_router->add_interest('published');
+        $pd_router->add_interest('publication_date');
+        $pd_router->add_interest('expires');
+        $pd_router->add_interest('linked_to_menu');
+        if (XH_ADM && $edit) {
+            $this->hidden = array_fill(0, $cl, false);
+            $this->published = array_fill(0, $cl, true);
+        } else {
+            foreach ($pd_router->find_all() as $index => $data) {
+                $this->hidden[$index] = $data['linked_to_menu'] == '0'
+                    || !$removed[$index] && hide($index);
+                $this->published[$index] = !$removed[$index]
+                    && $this->isPublishedInPageData($data);
+            }
+        }
+    }
+
+    /**
+     * Returns whether a page is published.
+     *
+     * A page may be unpublished either by `#cmsimple remove#` or via
+     * the page data fields `published`, `publication_date` and `expires`.
+     *
+     * @param int $index A page index.
+     *
+     * @return bool
+     */
+    public function isPublished($index)
+    {
+        return $this->published[$index];
+    }
+
+    /**
+     * Returns whether a page is hidden.
+     *
+     * A page may be hidden either by `#cmsimple hide#` or via the page data
+     * field `linked_to_menu`. Note that unpublished pages are not reported as
+     * being hidden by this method.
+     *
+     * @param int $index A page index.
+     *
+     * @return bool
+     */
+    public function isHidden($index)
+    {
+        return $this->hidden[$index];
+    }
+
+    /**
+     * Returns the index of the first published page.
+     *
+     * @return int
+     */
+    public function getFirstPublishedPage()
+    {
+        return array_search(true, $this->published, true);
+    }
+
+    /**
+     * Returns whether a page is hidden.
+     *
+     * @param array $data An array of page data.
+     *
+     * @return bool
+     */
+    protected function isPublishedInPageData(array $data)
+    {
+        if ($data['published'] == '0') {
+            return false;
+        }
+        $publication_date = isset($data['publication_date'])
+            ? trim($data['publication_date'])
+            : '';
+        $expires = isset($data['expires']) ? trim($data['expires']) : '';
+        if ($expires != '' || $publication_date != '') {
+            $current = time();
+            $maxInt = defined('PHP_INT_MAX') ? PHP_INT_MAX : 2147483647;
+            $int_publication_date = ($publication_date != '')
+                ? strtotime($publication_date) : 0;
+            $int_expiration_date = ($expires != '')
+                ? strtotime($expires) : $maxInt;
+            if ($current <= $int_publication_date
+                || $current >= $int_expiration_date
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+?>

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -952,17 +952,15 @@ $cl = 0;
 $pd_router = null;
 
 /**
- * The index of the first published page.
+ * The publisher instance.
  *
- * Treat as <i>read-only</i>.
- *
- * @global int $_XH_firstPublishedPage
+ * @global int $xh_publisher
  *
  * @access public
  *
- * @since 1.6.3
+ * @since 1.7.0
  */
-$_XH_firstPublishedPage = -1;
+$xh_publisher = null;
 
 /**
  * The index of the currently requested page.
@@ -1080,7 +1078,7 @@ if (XH_ADM) {
  *
  * @see $s
  */
-$pd_s = ($s == -1 && !$f && $o == '' && $su == '') ? $_XH_firstPublishedPage : $s;
+$pd_s = ($s == -1 && !$f && $o == '' && $su == '') ? $xh_publisher->getFirstPublishedPage() : $s;
 
 /**
  * The infos about the current page.
@@ -1313,8 +1311,7 @@ if (XH_ADM) {
 
 // fix $s
 if ($s == -1 && !$f && $o == '' && $su == '') {
-    $s = $_XH_firstPublishedPage;
-    $hs = $_XH_firstPublishedPage;
+    $s = $hs = $xh_publisher->getFirstPublishedPage();
 }
 
 if (XH_ADM) {

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -676,12 +676,13 @@ function e($et, $ft, $fn)
  * @global array  The localization of the core.
  * @global string Error messages as HTML fragment consisting of LI Elements.
  * @global object The pagedata router.
+ * @global object The publisher.
  *
  * @return void
  */
 function rfc()
 {
-    global $edit, $c, $cl, $h, $u, $l, $su, $s, $tx, $e, $pth, $pd_router;
+    global $edit, $c, $cl, $h, $u, $l, $su, $s, $tx, $e, $pth, $pd_router, $xh_publisher;
 
     $contents = XH_readContents();
     if ($contents === false) {
@@ -732,6 +733,8 @@ function rfc()
             }
         }
     }
+
+    $xh_publisher = new XH\Publisher($removed);
 }
 
 /**
@@ -753,7 +756,6 @@ function rfc()
  * @global array The paths of system files and folders.
  * @global array The configuration of the core.
  * @global bool  Whether edit mode is active.
- * @global int   The index of the first published page.
  *
  * @return array
  *
@@ -761,7 +763,7 @@ function rfc()
  */
 function XH_readContents($language = null)
 {
-    global $pth, $cf, $edit, $_XH_firstPublishedPage;
+    global $pth, $cf, $edit;
 
     if (isset($language)) {
         $contentFolder = $pth['folder']['base'] . 'content/' . $language . '/';
@@ -849,15 +851,9 @@ function XH_readContents($language = null)
     );
 
     // remove unpublished pages
-    if (!isset($language)) {
-        $_XH_firstPublishedPage = 0;
-    }
     if (!($edit && XH_ADM)) {
         foreach ($c as $i => $text) {
             if (cmscript('remove', $text)) {
-                if (!isset($language) && $_XH_firstPublishedPage == $i) {
-                    $_XH_firstPublishedPage = ($i < count($c) - 1) ? $i + 1 : -1;
-                }
                 $c[$i] = '#CMSimple hide# #CMSimple shead(404);#';
                 $removed[$i] = true;
             }
@@ -2734,28 +2730,29 @@ function XH_pluginURL($plugin)
  * @global array  The menu levels of the pages.
  * @global array  The localization of the core.
  * @global array  The configuration of the core.
- * @global int    The index of the first published page.
+ * @global object The publisher.
  *
  * @since 1.7
  */
 function XH_getLocatorModel()
 {
-    global $title, $h, $s, $f, $l, $tx, $cf, $_XH_firstPublishedPage;
+    global $title, $h, $s, $f, $l, $tx, $cf, $xh_publisher;
 
     if (hide($s) && $cf['show_hidden']['path_locator'] != 'true') {
         return array(array($h[$s], XH_getPageURL($s)));
     }
-    if ($s == $_XH_firstPublishedPage) {
+    $firstPublishedPage = $xh_publisher->getFirstPublishedPage();
+    if ($s == $firstPublishedPage) {
         return array(array($h[$s], XH_getPageURL($s)));
     } elseif ($title != '' && (!isset($h[$s]) || $h[$s] != $title)) {
         $res = array(array($title, null));
     } elseif ($f != '') {
         return array(array(ucfirst($f), null));
-    } elseif ($s > $_XH_firstPublishedPage) {
+    } elseif ($s > $firstPublishedPage) {
         $res = array();
         $tl = $l[$s];
         if ($tl > 1) {
-            for ($i = $s - 1; $i > $_XH_firstPublishedPage; $i--) {
+            for ($i = $s - 1; $i > $firstPublishedPage; $i--) {
                 if ($l[$i] < $tl) {
                     array_unshift($res, array($h[$i], XH_getPageURL($i)));
                     $tl--;
@@ -2771,14 +2768,14 @@ function XH_getLocatorModel()
     if ($cf['locator']['show_homepage'] == 'true') {
         array_unshift(
             $res,
-            array($tx['locator']['home'], XH_getPageURL($_XH_firstPublishedPage))
+            array($tx['locator']['home'], XH_getPageURL($firstPublishedPage))
         );
-        if ($s > $_XH_firstPublishedPage && $h[$s] == $title) {
+        if ($s > $firstPublishedPage && $h[$s] == $title) {
             $res[] = array($h[$s], XH_getPageURL($s));
         }
         return $res;
     } else {
-        if ($s > $_XH_firstPublishedPage && $h[$s] == $title) {
+        if ($s > $firstPublishedPage && $h[$s] == $title) {
             $res[] = array($h[$s], XH_getPageURL($s));
         }
         return $res;

--- a/plugins/page_params/index.php
+++ b/plugins/page_params/index.php
@@ -56,42 +56,6 @@ function Pageparams_handleRelocation($index, array $data)
 }
 
 /**
- * Returns whether the page is published.
- *
- * @param array $pd_page The page data of a page.
- *
- * @return bool
- *
- * @author Jerry Jakobsfeld <mail@simplesolutions.dk>
- *
- * @since 1.6
- */
-function Pageparams_isPublished(array $pd_page)
-{
-    if ($pd_page['published'] == '0') {
-        return false;
-    }
-    $publication_date = isset($pd_page['publication_date'])
-        ? trim($pd_page['publication_date'])
-        : '';
-    $expires = isset($pd_page['expires']) ? trim($pd_page['expires']) : '';
-    if ($expires != '' || $publication_date != '') {
-        $current = time();
-        $maxInt = defined('PHP_INT_MAX') ? PHP_INT_MAX : 2147483647;
-        $int_publication_date = ($publication_date != '')
-            ? strtotime($publication_date) : 0;
-        $int_expiration_date = ($expires != '')
-            ? strtotime($expires) : $maxInt;
-        if ($current <= $int_publication_date
-            || $current >= $int_expiration_date
-        ) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
  * Switches the template if a page specific is defined. Page specific templates
  * of super pages are inherited if not overridden.
  *
@@ -139,11 +103,7 @@ function Pageparams_switchTemplate($n)
 $pd_router->add_interest('heading');
 $pd_router->add_interest('show_heading');
 $pd_router->add_interest('template');
-$pd_router->add_interest('published');
-$pd_router->add_interest('publication_date');
-$pd_router->add_interest('expires');
 $pd_router->add_interest('show_last_edit');
-$pd_router->add_interest('linked_to_menu');
 $pd_router->add_interest('header_location');
 $pd_router->add_interest('use_header_location');
 
@@ -201,22 +161,18 @@ if (!(XH_ADM && $edit)) {
     if ($pd_s >= 0) {
         Pageparams_handleRelocation($pd_s, $pd_router->find_page($pd_s));
     }
-    $temp = $pd_router->find_all();
-    foreach ($temp as $i => $j) {
+    for ($i = 0; $i < $cl; $i++) {
         // unpublishing superseedes hiding:
-        if (!Pageparams_isPublished($j)) {
+        if (!$xh_publisher->isPublished($i)) {
             $c[$i] = '#CMSimple hide#';
-            if ($_XH_firstPublishedPage == $i) {
-                $_XH_firstPublishedPage = ($i < count($temp) - 1 ? $i + 1 : -1);
-            }
             if ($s == $i) {
                 $s = -1;
             }
             if ($pd_s == $i) {
-                $pd_s = ($i < count($temp) - 1 ? $i + 1 : -1);
+                $pd_s = ($i < $cl - 1 ? $i + 1 : -1);
                 $c[$i] .= '#CMSimple shead(404);#';
             }
-        } elseif ($j['linked_to_menu'] == '0') {
+        } elseif ($xh_publisher->isHidden($i)) {
             $c[$i] = '#CMSimple hide#' . $c[$i];
         }
     }

--- a/tests/unit/LocatorModelTest.php
+++ b/tests/unit/LocatorModelTest.php
@@ -32,11 +32,14 @@ class LocatorModelTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        global $sn, $_XH_firstPublishedPage, $f, $cf, $tx;
+        global $sn, $f, $cf, $tx, $xh_publisher;
 
         $this->setUpContent();
         $sn = '';
-        $_XH_firstPublishedPage = 0;
+        $xh_publisher = $this->getMockBuilder('XH\\Publisher')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $xh_publisher->method('getFirstPublishedPage')->willReturn(0);
         $f = '';
         $cf = array(
             'locator' => array('show_homepage' => 'true'),
@@ -153,9 +156,12 @@ class LocatorModelTest extends PHPUnit_Framework_TestCase
 
     public function testUnpublishedHomePage()
     {
-        global $_XH_firstPublishedPage, $s;
+        global $s, $xh_publisher;
 
-        $_XH_firstPublishedPage = 1;
+        $xh_publisher = $this->getMockBuilder('XH\\Publisher')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $xh_publisher->method('getFirstPublishedPage')->willReturn(1);
         $s = 0;
         $this->assertEquals(array(array('&nbsp;', null)), XH_getLocatorModel());
     }

--- a/tests/unit/PublisherTest.php
+++ b/tests/unit/PublisherTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Test case for the Publisher class.
+ *
+ * PHP version 5
+ *
+ * @category  Testing
+ * @package   XH
+ * @author    The CMSimple_XH developers <devs@cmsimple-xh.org>
+ * @copyright 2017 The CMSimple_XH developers <http://cmsimple-xh.org/?The_Team>
+ * @license   http://www.gnu.org/licenses/gpl-3.0.en.html GNU GPLv3
+ * @link      http://cmsimple-xh.org/
+ */
+
+namespace XH;
+
+use PHPUnit_Framework_TestCase;
+
+class PublisherTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Publisher
+     */
+    private $subject;
+
+    protected function setUp()
+    {
+        global $pd_router, $edit, $c;
+
+        $this->redefineConstant('XH_ADM', false);
+        $edit = false;
+        $pd_router = $this->getMockBuilder('XH\\PageDataRouter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pd_router->method('find_all')->willReturn(array(
+            0 => array(
+                'linked_to_menu' => '1',
+                'published' => '1',
+                'publication_date' => '',
+                'expires' => ''
+            ),
+            1 => array(
+                'linked_to_menu' => '1',
+                'published' => '0',
+                'publication_date' => '',
+                'expires' => ''
+            ),
+            2 => array(
+                'linked_to_menu' => '0',
+                'published' => '1',
+                'publication_date' => '',
+                'expires' => ''
+            ),
+            3 => array(
+                'linked_to_menu' => '0',
+                'published' => '0',
+                'publication_date' => '',
+                'expires' => ''
+            ),
+            4 => array(
+                'linked_to_menu' => '1',
+                'published' => '1',
+                'publication_date' => '1970-01-01',
+                'expires' => '2037-12-31'
+            ),
+            5 => array(
+                'linked_to_menu' => '1',
+                'published' => '1',
+                'publication_date' => '2037-12-31',
+                'expires' => ''
+            ),
+            6 => array(
+                'linked_to_menu' => '1',
+                'published' => '1',
+                'publication_date' => '',
+                'expires' => '1970-01-01'
+            ),
+            7 => array(
+                'linked_to_menu' => '1',
+                'published' => '1',
+                'publication_date' => '',
+                'expires' => ''
+            ),
+            8 => array(
+                'linked_to_menu' => '1',
+                'published' => '1',
+                'publication_date' => '',
+                'expires' => ''
+            )
+        ));
+        $c = array(
+            0 => '',
+            1 => '',
+            2 => '',
+            3 => '',
+            4 => '',
+            5 => '',
+            6 => '',
+            7 => '',
+            8 => '#cmsimple hide#'
+        );
+        $this->subject = new Publisher([false, false, false, false, false, false, false, true, false]);
+    }
+
+    /**
+     * @param string $name
+     */
+    private function redefineConstant($name, $value)
+    {
+        if (!defined($name)) {
+            define($name, $value);
+        } else {
+            runkit_constant_redefine($name, $value);
+        }
+    }
+
+    /**
+     * @dataProvider provideIsPublishedData
+     * @param int $index
+     * @param bool $expected
+     */
+    public function testIsPublished($index, $expected)
+    {
+        $this->assertSame($expected, $this->subject->isPublished($index));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideIsPublishedData()
+    {
+        return array(
+            [0, true],
+            [1, false],
+            [2, true],
+            [3, false],
+            [4, true],
+            [5, false],
+            [6, false],
+            [7, false]
+        );
+    }
+
+    /**
+     * @dataProvider provideIsHiddenData
+     * @param int $index
+     * @param bool $expected
+     */
+    public function testIsHidden($index, $expected)
+    {
+        $this->assertSame($expected, $this->subject->isHidden($index));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideIsHiddenData()
+    {
+        return array(
+            [0, false],
+            [1, false],
+            [2, true],
+            [3, true],
+            [8, true]
+        );
+    }
+
+    public function testGetFirstPublishedPage()
+    {
+        $this->assertSame(0, $this->subject->getFirstPublishedPage());
+    }
+}
+
+?>


### PR DESCRIPTION
At least the basic functionality regarding publishing and hiding of
pages (i.e. the page_params alternatives to `#cmsimple hide#` and
`#cmsimple remove#`) shouldn't be handled by a plugin, but rather by
the core, because:

* `#cmsimple remove#` can't be detected by a plugin as it is already
  converted during content loading
* during plugin loading `hide()` may yield wrong results
* other plugins should have a simple means to detect whether a page is
  hidden or unpublished

Therefore, we extract the functionality to detect whether a page is
hidden and published into the new class Publisher whose sole instance
is globally available as `$xh_publisher`. As Publisher is perfectly
capable to determine the first published page, we don't have to track
that in the global `$_XH_firstPublishedPage` anymore, so we remove this
variable, what is a potential BC break, but we're convinced that the
benefits of encapsulating the hide/unpublish functionality in a class
clearly outweighs the drawbacks of this BC break.

Future scope: Publisher may also take the responsibility to modify the
page content for unpublished and hidden pages, and might offer an API
for third-party plugins to mark pages as hidden or unpublished.