### PR TITLE
Close #188: Dump .plugintext, .pluginedit and .plugineditcaption

### DIFF
--- a/assets/css/core.css
+++ b/assets/css/core.css
@@ -290,23 +290,6 @@ li.xh_system_check_cat_start {
 }
 
 /*
- * Pluginloader
- */
-
-div.pluginedit,
-div.plugintext {
-    border: 0px solid #828177;
-    padding: 4px 0;
-}
-
-div.plugineditcaption {
-    font-family: arial, sans-serif;
-    font-size: 15px;
-    font-weight: bold;
-    padding: 6px 0;
-}
-
-/*
  * Configuration
  */
 

--- a/plugins/filebrowser/admin.php
+++ b/plugins/filebrowser/admin.php
@@ -31,10 +31,6 @@ $_XH_filebrowser->setMaxFileSize('downloads', $cf['downloads']['maxsize']);
 if (XH_wantsPluginAdministration('filebrowser')) {
     $o .= print_plugin_admin('off');
 
-    $o .= '<div class="plugintext">'
-        . '<div class="plugineditcaption">Filebrowser for @CMSIMPLE_XH_VERSION@'
-        . '</div>' . '<hr>';
-
     if (!$admin) {
         $admin = 'plugin_config';
     }
@@ -42,8 +38,7 @@ if (XH_wantsPluginAdministration('filebrowser')) {
         $action = 'plugin_edit';
     }
 
-    $o .= plugin_admin_common($action, $admin, $plugin)
-        . '</div>';
+    $o .= plugin_admin_common($action, $admin, $plugin);
     return;
 }
 

--- a/plugins/meta_tags/admin.php
+++ b/plugins/meta_tags/admin.php
@@ -34,8 +34,8 @@ if (!defined('PLUGINLOADER')) {
 if (XH_wantsPluginAdministration('meta_tags')) {
     $o .= print_plugin_admin('off');
     if ($admin == '') {
-        $o .= "\n" . '<div class="plugintext"><div class="plugineditcaption">'
-            . ucfirst(str_replace('_', ' ', $plugin)) . '</div></div>' . '<br>';
+        $o .= "\n" . '<h1>'
+            . ucfirst(str_replace('_', ' ', $plugin)) . '</h1>';
     }
     $o .= plugin_admin_common($action, $admin, $plugin);
 }

--- a/plugins/page_params/admin.php
+++ b/plugins/page_params/admin.php
@@ -35,9 +35,8 @@ if (!defined('PLUGINLOADER')) {
 if (XH_wantsPluginAdministration('page_params')) {
     $o .= print_plugin_admin('off');
     if ($admin == '') {
-        $o .= "\n" . '<div class="plugintext"><div class="plugineditcaption">'
-            . utf8_ucfirst(str_replace('_', ' ', $plugin)) . '</div></div>'
-            . '<br>';
+        $o .= "\n" . '<h1>'
+            . utf8_ucfirst(str_replace('_', ' ', $plugin)) . '</h1>';
     }
     $o .= plugin_admin_common($action, $admin, $plugin);
 }


### PR DESCRIPTION
These CSS classes have been mostly superseeded by the new configuration
forms introduced with CMSimple_XH 1.6, and they are rarely if ever used
by newer plugins. We don't regard them as being particularly useful,
anyway, as they convey no semantic meaning, so we remove them from the
core and the standard plugins.