### PR TITLE
Close #143: Lazy loading of plugin config and language files

### DIFF
--- a/cmsimple/classes/PluginConfig.php
+++ b/cmsimple/classes/PluginConfig.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Abstraction over the plugin (language) configuration.
+ *
+ * PHP version 5
+ *
+ * @category  CMSimple_XH
+ * @package   XH
+ * @author    The CMSimple_XH developers <devs@cmsimple-xh.org>
+ * @copyright 2017 The CMSimple_XH developers <http://cmsimple-xh.org/?The_Team>
+ * @license   http://www.gnu.org/licenses/gpl-3.0.en.html GNU GPLv3
+ * @link      http://cmsimple-xh.org/
+ */
+
+namespace XH;
+
+use ArrayAccess;
+
+/**
+ * Abstraction over the plugin (language) configuration.
+ *
+ * Instead of plain arrays, `$plugin_cf` and `$plugin_tx` are objects, which
+ * allow for lazy loading of the configuration and language files, respectively. 
+ *
+ * @category CMSimple_XH
+ * @package  XH
+ * @author   The CMSimple_XH developers <devs@cmsimple-xh.org>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.en.html GNU GPLv3
+ * @link     http://cmsimple-xh.org/
+ * @since    1.7.0
+ */
+class PluginConfig implements ArrayAccess
+{
+    /**
+     * Whether this is a language configuration.
+     *
+     * @var bool
+     */
+    protected $language;
+
+    /**
+     * The loaded plugin configurations.
+     *
+     * @var array
+     */
+    protected $configs = array();
+
+    /**
+     * Initializes a new instance.
+     *
+     * @param bool $language Whether this is a language configuration.
+     */
+    public function __construct($language = false)
+    {
+        $this->language = $language;
+    }
+
+    /**
+     * Returns whether an offset exists.
+     *
+     * @param mixed $offset An offset.
+     *
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        if (!isset($this->configs[$offset])) {
+            $this->loadConfig($offset);
+        }
+        return isset($this->configs[$offset]);
+    }
+
+    /**
+     * Returns the value at an offset.
+     *
+     * @param mixed $offset An offset.
+     *
+     * @return array
+     */
+    public function offsetGet($offset)
+    {
+        if (!isset($this->configs[$offset])) {
+            $this->loadConfig($offset);
+        }
+        return $this->configs[$offset];
+    }
+
+    /**
+     * Sets the value at an offset.
+     *
+     * @param mixed $offset An offset.
+     * @param mixed $value  A value.
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (!isset($this->configs[$offset])) {
+            $this->loadConfig($offset);
+        }
+        $this->configs[$offset] = $value;
+    }
+
+    /**
+     * Unsets an offset.
+     *
+     * @param mixed $offset An offset.
+     *
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        if (!isset($this->configs[$offset])) {
+            $this->loadConfig($offset);
+        }
+        unset($this->configs[$offset]);
+    }
+
+    /**
+     * Loads the configuration.
+     *
+     * @param string $pluginname A plugin name.
+     *
+     * @return void
+     */
+    protected function loadConfig($pluginname)
+    {
+        global $pth;
+    
+        pluginFiles($pluginname);
+        if ($this->language) {
+            XH_createLanguageFile($pth['file']['plugin_language']);
+        }
+        $this->configs += XH_readConfiguration(true, $this->language);
+    }
+}
+
+?>

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -1098,38 +1098,26 @@ $pd_current = $pd_router->find_page($pd_s);
  *
  * Treat as <i>read-only</i>.
  *
- * @global array $plugin_cf
+ * @global XH\PluginConfig $plugin_cf
  *
  * @access public
  *
  * @see $cf
  */
-$plugin_cf = array();
+$plugin_cf = new XH\PluginConfig();
 
 /**
  * The localization of the plugins.
  *
  * Treat as <i>read-only</i>.
  *
- * @global array $plugin_tx
+ * @global XH\PluginConfig $plugin_tx
  *
  * @access public
  *
  * @see $tx
  */
-$plugin_tx = array();
-
-/*
- * Include config and language files of all plugins.
- */
-foreach (XH_plugins() as $plugin) {
-    pluginFiles($plugin);
-    $temp = XH_readConfiguration(true, false);
-    $plugin_cf += $temp;
-    XH_createLanguageFile($pth['file']['plugin_language']);
-    $temp = XH_readConfiguration(true, true);
-    $plugin_tx += $temp;
-}
+$plugin_tx = new XH\PluginConfig(true);
 
 /*
  * Add LINK to combined plugin stylesheet.

--- a/plugins/jquery/jquery.inc.php
+++ b/plugins/jquery/jquery.inc.php
@@ -27,7 +27,7 @@ if (!defined('CMSIMPLE_XH_VERSION')) {
 global $hjs, $plugin_cf, $pth;
 
 //load plugin-configuration for xh < 1.6
-require($pth['folder']['plugins'] . 'jquery/config/config.php');
+//require($pth['folder']['plugins'] . 'jquery/config/config.php');
 
 function include_jQuery($path = '') {
     global $pth, $plugin_cf, $hjs;

--- a/plugins/tinymce4/init.php
+++ b/plugins/tinymce4/init.php
@@ -148,8 +148,8 @@ function tinymce4_config($config, $selector)
 {
     global $cl, $pth, $sl, $cf, $plugin_cf, $plugin_tx, $s;
 
-    $pcf = &$plugin_cf['tinymce4'];
-    $ptx = &$plugin_tx['tinymce4'];
+    $pcf = $plugin_cf['tinymce4'];
+    $ptx = $plugin_tx['tinymce4'];
     $pluginName = basename(dirname(__FILE__), "/");
     $pluginPth = $pth['folder']['plugins'] . $pluginName . '/';
 


### PR DESCRIPTION
We change `$plugin_cf` and `$plugin_tx` to objects implementing
`ArrayAccess` instead of arrays to be able to lazily load the
configuration and language files without breaking backward
compatibility.