### PR TITLE
Close #215: Write session name to file in cmsimple/ folder

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2656,8 +2656,12 @@ function XH_autoload($className)
  */
 function XH_startSession()
 {
+    global $pth;
+
     if (session_id() == '') {
-        session_name('XH_' . bin2hex(CMSIMPLE_ROOT));
+        $sessionName = 'XH_' . bin2hex(CMSIMPLE_ROOT);
+        file_put_contents("{$pth['folder']['cmsimple']}.sessionname", $sessionName);
+        session_name($sessionName);
         session_start();
     }
 }

--- a/tests/unit/ControllerTest.php
+++ b/tests/unit/ControllerTest.php
@@ -563,6 +563,7 @@ class ControllerLoginTest extends ControllerLogInOutTestCase
         $this->logMessageMock = new PHPUnit_Extensions_MockFunction(
             'XH_logMessage', $this->subject
         );
+        new PHPUnit_Extensions_MockFunction('file_put_contents', $this->subject);
     }
 
     /**
@@ -714,6 +715,7 @@ class ControllerLogoutTest extends ControllerLogInOutTestCase
         $this->backupMock = new PHPUnit_Extensions_MockFunction(
             'XH_backup', $this->subject
         );
+        new PHPUnit_Extensions_MockFunction('file_put_contents', $this->subject);
     }
 
     /**


### PR DESCRIPTION
Whenever a session is started via `XH_startSession()`, we update
cmsimple/.sessionname to contain the current session name. This
simplifies to reuse the CMSimple_XH session in external scripts.