### PR TITLE
Close #198: Drop support for legal notices page

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -1193,18 +1193,6 @@ $si = -1;
 
 XH_buildHc();
 
-// LEGAL NOTICES - not needed under GPL3
-if (empty($cf['menu']['legal'])) {
-    $cf['menu']['legal'] = 'CMSimple Legal Notices';
-}
-if ($su == uenc($cf['menu']['legal'])) {
-    $f = $title = $cf['menu']['legal'];
-    $s = -1;
-    $o .= '<h1>' . $title . '</h1>'
-        . file_get_contents($pth['folder']['cmsimple'] . 'legal.txt');
-}
-
-
 /*
  * Enables the automatic creation of a "Site/CMS Info" page.
  * To generate a link to this page add <?php echo poweredbylink()?>

--- a/cmsimple/compat.php
+++ b/cmsimple/compat.php
@@ -104,25 +104,6 @@ function guestbooklink()
 }
 
 /**
- * Returns the link to the copyright and license informations.
- *
- * @return string HTML
- *
- * @global array  The configuration of the core.
- * @global string The script name.
- *
- * @deprecated since 1.5.8
- */
-function legallink()
-{
-    global $cf, $sn;
-
-    trigger_error('Function ' . __FUNCTION__ . '() is deprecated', E_USER_DEPRECATED);
-    return '<a href="' . $sn . '?' . uenc($cf['menu']['legal']) . '">'
-        . $cf['menu']['legal'] . '</a>';
-}
-
-/**
  * Returns whether the file exists in the download folder
  * and is available for download.
  *

--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -36,7 +36,6 @@ $cf['menu']['highlightcolor']="808080";
 $cf['menu']['levels']="3";
 $cf['menu']['levelcatch']="10";
 $cf['menu']['sdoc']="parent";
-$cf['menu']['legal']="CMSimple Legal Notices";
 $cf['plugins']['disabled']="";
 $cf['plugins']['hidden']="meta_tags,page_params";
 $cf['uri']['seperator']="/";

--- a/cmsimple/metaconfig.php
+++ b/cmsimple/metaconfig.php
@@ -26,7 +26,6 @@ $mcf['menu']['color']="hidden";
 $mcf['menu']['highlightcolor']="hidden";
 $mcf['menu']['levels']="hidden";
 $mcf['menu']['levelcatch']="hidden";
-$mcf['menu']['legal']="hidden";
 $mcf['menu']['sdoc']="enum:,parent";
 $mcf['uri']['length']="hidden";
 $mcf['editmenu']['scroll']="bool";

--- a/tests/unit/TplfuncsTest.php
+++ b/tests/unit/TplfuncsTest.php
@@ -144,14 +144,6 @@ class TplfuncsTest extends PHPUnit_Framework_TestCase
         guestbooklink();
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Deprecated
-     */
-    public function testLegallinkIsDeprecated()
-    {
-        legallink();
-    }
-
     public function testEditmenu()
     {
         $errorReporting = error_reporting();


### PR DESCRIPTION
We remove support for the implicit "legal notices" page, and
consequently remove the function `legallink()` which had been
deprecated as of CMSimple_XH 1.5.8, anyway.