### PR TITLE
Close #201: Deprecate initvar()

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -767,8 +767,6 @@ function print_plugin_admin($main)
 {
     global $_XH_pluginMenu;
 
-    initvar('action');
-    initvar('admin');
     return $_XH_pluginMenu->render(strtoupper($main) == 'ON');
 }
 

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -743,13 +743,21 @@ $validate = null;
 $xhpages = null;
 
 $temp = array(
-    'action', 'download', 'downloads', 'edit', 'file', 'function', 'images',
+    'action', 'admin', 'download', 'downloads', 'edit', 'file', 'function', 'images',
     'login', 'logout', 'keycut', 'mailform', 'media', 'normal', 'phpinfo', 'print', 'search',
     'selected', 'settings', 'sitemap', 'sysinfo', 'text', 'userfiles', 'validate', 'xhpages',
     'xh_backups', 'xh_change_password', 'xh_do_validate', 'xh_pagedata'
 );
 foreach ($temp as $i) {
-    initvar($i);
+    if (!isset($GLOBALS[$i])) {
+        if (isset($_GET[$i])) {
+            $GLOBALS[$i] = $_GET[$i];
+        } elseif (isset($_POST[$i])) {
+            $GLOBALS[$i] = $_POST[$i];
+        } else {
+            $GLOBALS[$i] = '';
+        }
+    }
 }
 
 /**

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -514,10 +514,12 @@ function XH_finalCleanUp($html)
  *
  * @return void
  *
- * @see http://www.cmsimpleforum.com/viewtopic.php?f=29&t=5315
+ * @deprecated since 1.7.0
  */
 function initvar($name)
 {
+    trigger_error('Function ' . __FUNCTION__ . '() is deprecated', E_USER_DEPRECATED);
+
     if (!isset($GLOBALS[$name])) {
         if (isset($_GET[$name])) {
             $GLOBALS[$name] = $_GET[$name];

--- a/tests/unit/ClassicPluginMenuTest.php
+++ b/tests/unit/ClassicPluginMenuTest.php
@@ -60,16 +60,6 @@ class ClassicPluginMenuTest extends PHPUnit_Framework_TestCase
         touch($pth['folder']['plugins'] . 'filebrowser/languages/en.php');
     }
 
-    public function testPluginMenuInitsAdminAndAction()
-    {
-        $initvar = new PHPUnit_Extensions_MockFunction('initvar', $this);
-        // We'd like to add ->withConsecutive() here, but that's not yet
-        // supported by PHPUnit 4.0 which we're relying on for now.
-        $initvar->expects($this->exactly(2));
-        print_plugin_admin('off');
-        $initvar->restore();
-    }
-
     public function testFullPluginMenuHas1Row()
     {
         $matcher = array(

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -172,6 +172,14 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     */
+    public function testInitvarIsDeprecated()
+    {
+        initvar('foo');
+    }
+
     public function dataForTestSv()
     {
         return array(


### PR DESCRIPTION
We see two issues regarding initvar():
* it initializes a *global* variable, whereas a local variable usually
  is sufficient
* it doesn't distinguish between GET and POST parameters, but neither
  allows to cater to COOKIEs and other inputs (as $_REQUEST does)

Therefore we deprecate `initvar()` and remove it's usage from the core.
To make updating affected plugins easier, we add $admin to the list of
variables which will be initialized by the core early, what makes
calling `initvar('admin')` definitely unnecessary.