### PR TITLE
Close #211: Objects are destroyed before XH_finalCleanUp() is called

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -1367,7 +1367,7 @@ if (XH_ADM) {
 
 $_XH_controller->verifyAdm();
 
-ob_start('XH_finalCleanUp');
+ob_start();
 
 $i = false;
 $temp = fopen($pth['file']['template'], 'r');
@@ -1385,3 +1385,5 @@ if (!$i) {// the template could not be included
 if (isset($_XH_csrfProtection)) {
     $_XH_csrfProtection->store();
 }
+
+echo XH_finalCleanUp(ob_get_clean());


### PR DESCRIPTION
A callback passed to `ob_start()` is executed during PHP's shutdown
sequence. Therefore the current working directory might have been
reset, and even worse, all objects have already been destroyed before
the callback is called.

Therefore, we do no longer pass a callback parameter to `ob_start()`,
but rather call the callback manually at the end of `cms.php`. This is
a BC break regarding modified `index.php`s, but we rather refrain from
putting the call in both `index.php`s we're shipping, and we suggest
that users also don't modify `index.php`, but rather use the newly
introduced `XH_afterFinalCleanUp()` hook to register a user function.