### PR TITLE
Close #92: Improve accessibility of the admin menu

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -364,6 +364,13 @@ function XH_settingsView()
 
     $o .= '<h4>' . $tx['settings']['backup'] . '</h4>' . "\n";
     $o .= XH_backupsView();
+    $o .= '<h4>' . $tx['settings']['more'] . '</h4>' . "\n"
+        . '<ul>' . "\n"
+        . '<li><a href="' . $sn . '?&validate">' . $tx['editmenu']['validate'] . '</a></li>'
+        . '<li><a href="' . $sn . '?&xh_pagedata">' .$tx['editmenu']['pagedata'] . '</a></li>'
+        . '<li><a href="' . $sn . '?&xh_change_password">' . $tx['editmenu']['change_password'] . '</a></li>'
+        . '<li><a href="' . $sn . '?&sysinfo">' . $tx['editmenu']['sysinfo'] . '</a></li>'
+        . '</ul>' . "\n";
     return $o;
 }
 
@@ -468,6 +475,41 @@ function XH_backupsView()
         }
     }
     $o .= '</ul>' . "\n";
+    return $o;
+}
+
+/**
+ * Returns the plugins view.
+ *
+ * @return string HTML
+ *
+ * @global array  The script name.
+ * @global array  The configuration of the core
+ * @global array  The localization of the core.
+ *
+ * @since 1.7
+ */
+function XH_pluginsView()
+{
+    global $sn, $cf, $tx;
+
+    $plugins = XH_plugins(true);
+    $hiddenPlugins = explode(',', $cf['plugins']['hidden']);
+    $hiddenPlugins = array_map('trim', $hiddenPlugins);
+    $plugins = array_diff($plugins, $hiddenPlugins);
+    natcasesort($plugins);
+    $plugins = array_values($plugins);
+
+    $o = '<h1>' . $tx['title']['plugins'] . '</h1><ul>';
+    foreach ($plugins as $plugin) {
+        $item = array(
+            'label' => utf8_ucfirst($plugin),
+            'url' => "$sn?$plugin&normal",
+            'children' => XH_registerPluginMenuItem($plugin)
+        );
+        $o .= XH_adminMenuItem($item, 0);
+    }
+    $o .= '</ul>';
     return $o;
 }
 
@@ -685,7 +727,7 @@ function XH_adminMenu(array $plugins = array())
         ),
         array(
             'label' => utf8_ucfirst($tx['editmenu']['plugins']),
-            'url' => $sn, // TODO: use more sensible URL
+            'url' => $sn . '?&xh_plugins',
             'children' => $pluginMenu,
             'id' => 'xh_adminmenu_plugins',
             'style' => 'width:' . $width . 'px; margin-left: ' . $marginLeft . 'px'

--- a/cmsimple/classes/Controller.php
+++ b/cmsimple/classes/Controller.php
@@ -339,7 +339,7 @@ class Controller
     {
         global $function, $validate, $xh_do_validate, $settings, $xh_backups,
             $xh_pagedata, $sysinfo, $phpinfo, $file, $userfiles, $images,
-            $downloads, $f, $xh_change_password;
+            $downloads, $f, $xh_change_password, $xh_plugins;
 
         if ($function == 'save') {
             $f = 'save';
@@ -367,6 +367,8 @@ class Controller
             $f = 'validate';
         } elseif ($xh_change_password) {
             $f = 'change_password';
+        } elseif ($xh_plugins) {
+            $f = 'xh_plugins';
         }
     }
 

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -746,7 +746,7 @@ $temp = array(
     'action', 'download', 'downloads', 'edit', 'file', 'function', 'images',
     'login', 'logout', 'keycut', 'mailform', 'media', 'normal', 'phpinfo', 'print', 'search',
     'selected', 'settings', 'sitemap', 'sysinfo', 'text', 'userfiles', 'validate', 'xhpages',
-    'xh_backups', 'xh_change_password', 'xh_do_validate', 'xh_pagedata'
+    'xh_backups', 'xh_change_password', 'xh_do_validate', 'xh_pagedata', 'xh_plugins'
 );
 foreach ($temp as $i) {
     initvar($i);
@@ -1288,6 +1288,9 @@ if (XH_ADM) {
             $temp = new XH\ChangePassword();
             $i = $action === 'save' ? 'save' : 'default';
             $temp->{"{$i}Action"}();
+            break;
+        case 'xh_plugins':
+            $o .= XH_pluginsView();
             break;
     }
 }

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -259,6 +259,7 @@ $tx['settings']['backupexplain1']="Beim Logout wird eine Sicherheitskopie des In
 $tx['settings']['backupexplain2']="Sicherheitskopie-Namen beginnen mit Datum und Uhrzeit der Erstellung: YYYYMMDD_HHMMSS";
 $tx['settings']['backupsuffix']="Geben Sie einen Dateinamen ein (nur a-z, 0-9, Minus und Unterstrich; höchstens 20 Zeichen):";
 $tx['settings']['ftp']="Bitte FTP zur Dateiverwaltung benutzen.";
+$tx['settings']['more']="Mehr";
 $tx['settings']['systemfiles']="Systemdateien";
 $tx['settings']['warning']="Bitte hier nur solche Änderungen durchführen, bei denen Sie genau wissen, was diese bewirken!";
 
@@ -305,6 +306,7 @@ $tx['title']['media']="Media-Dateien";
 $tx['title']['xh_pagedata']="Page-Data Bereinigung";
 $tx['title']['password_forgotten']="Passwort vergessen";
 $tx['title']['phpinfo']="PHP-Info";
+$tx['title']['plugins']="Plugins";
 $tx['title']['search']="Suchen";
 $tx['title']['settings']="Einstellungen";
 $tx['title']['sitemap']="Inhaltsverzeichnis";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -258,6 +258,7 @@ $tx['settings']['backupexplain1']="On logout content is backed up and the oldest
 $tx['settings']['backupexplain2']="Backup file names start with date and time of backup as: YYYYMMDD_HHMMSS";
 $tx['settings']['backupsuffix']="Enter a filename (only a-z, 0-9, minus and underscore; at most 20 characters):";
 $tx['settings']['ftp']="Use FTP for remote file management";
+$tx['settings']['more']="More";
 $tx['settings']['systemfiles']="System files";
 $tx['settings']['warning']="Only change settings when you understand the effect your changes will have!";
 
@@ -304,6 +305,7 @@ $tx['title']['media']="Mediafiles";
 $tx['title']['xh_pagedata']="Page Data Cleanup";
 $tx['title']['password_forgotten']="Password forgotten";
 $tx['title']['phpinfo']="PHP Info";
+$tx['title']['plugins']="Plugins";
 $tx['title']['search']="Search";
 $tx['title']['settings']="Settings";
 $tx['title']['sitemap']="Sitemap";

--- a/tests/unit/AdminMenuTest.php
+++ b/tests/unit/AdminMenuTest.php
@@ -128,22 +128,6 @@ class AdminMenuTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testShowsPluginsItem()
-    {
-        global $tx;
-
-        $matcher = array(
-            'tag' => 'a',
-            'attributes' => array('href' => '/'),
-            'content' => $tx['editmenu']['plugins'],
-            'ancestor' => array(
-                'tag' => 'div',
-                'id' => 'xh_adminmenu'
-            )
-        );
-        $this->_assertMatches($matcher);
-    }
-
     /**
      * @dataProvider pluginData
      */


### PR DESCRIPTION
The drop-down menus of the admin menu are not accessible on touch
devices and via the keyboard. We therefore make all functionality also
accessible from the toplevel items of the admin menu, i.e. we add yet
missing links to the settings page and introduce a new plugins page
with links to all enabled plugins and their registered menu items.