### PR TITLE
Change newsbox heading levels in the distro contents

### DIFF
--- a/2lang/content/content.htm
+++ b/2lang/content/content.htm
@@ -71,7 +71,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h4>Newsbox News01</h4>
+<h2>Newsbox News01</h2>
 <p>This box shows the content of the hidden page "News01".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes">CMSimple_XH Wiki &raquo;</a></p>
@@ -98,7 +98,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h4>Newsbox News02</h4>
+<h2>Newsbox News02</h2>
 <p>This box shows the content of the hidden page "News02".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes">CMSimple_XH Wiki &raquo;</a></p>
@@ -125,7 +125,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h4>Newsbox News03</h4>
+<h2>Newsbox News03</h2>
 <p>This box shows the content of the hidden page "News03".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes">CMSimple_XH Wiki &raquo;</a></p>

--- a/content/content.htm
+++ b/content/content.htm
@@ -1169,7 +1169,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h1>Newsbox News01</h1>
+<h2>Newsbox News01</h2>
 <p>This box shows the content of the hidden page "News01".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes" target="_blank" rel="noopener noreferrer">CMSimple_XH Wiki</a></p>
@@ -1196,7 +1196,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h1>Newsbox News02</h1>
+<h2>Newsbox News02</h2>
 <p>This box shows the content of the hidden page "News02".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes" target="_blank" rel="noopener noreferrer">CMSimple_XH Wiki</a></p>
@@ -1223,7 +1223,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h1>Newsbox News03</h1>
+<h2>Newsbox News03</h2>
 <p>This box shows the content of the hidden page "News03".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes" target="_blank" rel="noopener noreferrer">CMSimple_XH Wiki</a></p>
@@ -1250,7 +1250,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h1>Newsbox News04</h1>
+<h2>Newsbox News04</h2>
 <p>This box shows the content of the hidden page "News04".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes" target="_blank" rel="noopener noreferrer">CMSimple_XH Wiki</a></p>
@@ -1277,7 +1277,7 @@ $page_data[]=array(
 'expires'=>''
 );
 ?>
-<h1>Newsbox News05</h1>
+<h2>Newsbox News05</h2>
 <p>This box shows the content of the hidden page "News05".</p>
 <p>More information about newsboxes can be found here:</p>
 <p style="text-align: right;"><a href="http://www.cmsimple-xh.org/wiki/doku.php/newsboxes" target="_blank" rel="noopener noreferrer">CMSimple_XH Wiki</a></p>


### PR DESCRIPTION
CMSimple_XH 1.7 gives the possibility to have a clean heading
structure, and this should be reflected by the distro contents.
Therefore, we change `<h1>` and `<h4>`, respectively, to `<h2>`, see
#179.