### PR TITLE
Close #196: Improve Site/CMS info

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2679,9 +2679,8 @@ function XH_poweredBy()
 {
     global $cf, $tx, $pth;
 
-    $o = '<h5>Content Management System</h5>'
-        . '<ul><li><a href="http://cmsimple-xh.org">'
-        . CMSIMPLE_XH_VERSION . '</a></li></ul>';
+    $o = '<h5>' . $tx['title']['cms'] . '</h5>'
+        . '<ul><li><a href="http://cmsimple-xh.org">CMSimple_XH</a></li></ul>';
     $defaulttpl = $tx['subsite']['template'] == ''
         ? $cf['site']['template']
         : $tx['subsite']['template'];
@@ -2689,8 +2688,8 @@ function XH_poweredBy()
     $tpltext = '';
     foreach (XH_templates() as $template) {
         $tpltext .= $defaulttpl == $template
-            ? '<li><p><strong>Default template: ' . ucfirst($template) . '</strong>'
-            : '<li>' . ucfirst($template);
+            ? '<dt>' . $tx['template']['active'] . ucfirst($template) . '</dt>'
+            : '<dt>' . ucfirst($template) . '</dt>';
         $infoPath = $pth['folder']['templates'] . '/' . $template . '/templateinfo.htm';
         if (is_file($infoPath)) {
             $tplinfo = utf8_substr(
@@ -2698,14 +2697,15 @@ function XH_poweredBy()
                 0,
                 400
             );
+            $tpltext .= '<dd>';
             if ($tplinfo) {
-                $tpltext .= '<br>' . $tplinfo;
+                $tpltext .= $tplinfo;
             }
+            $tpltext .= '</dd>';
         }
-        $tpltext .= '</li>';
     }
 
-    $o .= '<h5>Templates</h5><ul>' . $tpltext . '</ul>';
+    $o .= '<h5>' . $tx['title']['templates'] . '</h5><dl>' . $tpltext . '</dl>';
     $t = '';
     foreach (XH_plugins() as $plugin) {
         $url = XH_pluginURL($plugin);
@@ -2714,7 +2714,7 @@ function XH_poweredBy()
                 . '</a></li>';
         }
     }
-    $o .= $t? '<h5>Plugins</h5><ul>' . $t . '</ul>' : '';
+    $o .= $t? '<h5>' . $tx['title']['plugins'] . '</h5><ul>' . $t . '</ul>' : '';
     return $o;
 }
 

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -293,10 +293,12 @@ $tx['sysinfo']['version']="Installierte CMSimple Version";
 $tx['sysinfo']['unknown']="Webserver konnte nicht ermittelt werden";
 $tx['sysinfo']['webserver']="Webserver";
 
+$tx['template']['active']="Aktives Template: ";
 $tx['template']['default']="Standard Template";
 
 $tx['title']['bad_request']="Inkorrekte Anfrage";
 $tx['title']['change_password']="Passwort ändern";
+$tx['title']['cms']="Content Management System";
 $tx['title']['downloads']="Downloads";
 $tx['title']['images']="Bilder";
 $tx['title']['log']="Log-Datei";
@@ -305,10 +307,12 @@ $tx['title']['media']="Media-Dateien";
 $tx['title']['xh_pagedata']="Page-Data Bereinigung";
 $tx['title']['password_forgotten']="Passwort vergessen";
 $tx['title']['phpinfo']="PHP-Info";
+$tx['title']['plugins']="Plugins";
 $tx['title']['search']="Suchen";
 $tx['title']['settings']="Einstellungen";
 $tx['title']['sitemap']="Inhaltsverzeichnis";
 $tx['title']['sysinfo']="System-Info";
+$tx['title']['templates']="Templates";
 $tx['title']['userfiles']="Andere";
 $tx['title']['validate']="Links prüfen";
 $tx['title']['xh_backups']="Sicherheitskopien";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -292,10 +292,12 @@ $tx['sysinfo']['version']="Installed CMSimple Version";
 $tx['sysinfo']['unknown']="Webserver could not be determined";
 $tx['sysinfo']['webserver']="Webserver";
 
+$tx['template']['active']="Active Template: ";
 $tx['template']['default']="default template";
 
 $tx['title']['bad_request']="Bad request";
 $tx['title']['change_password']="Change Password";
+$tx['title']['cms']="Content Management System";
 $tx['title']['downloads']="Downloads";
 $tx['title']['images']="Images";
 $tx['title']['log']="Log File";
@@ -304,10 +306,12 @@ $tx['title']['media']="Mediafiles";
 $tx['title']['xh_pagedata']="Page Data Cleanup";
 $tx['title']['password_forgotten']="Password forgotten";
 $tx['title']['phpinfo']="PHP Info";
+$tx['title']['plugins']="Plugins";
 $tx['title']['search']="Search";
 $tx['title']['settings']="Settings";
 $tx['title']['sitemap']="Sitemap";
 $tx['title']['sysinfo']="System Info";
+$tx['title']['templates']="Templates";
 $tx['title']['userfiles']="Userfiles";
 $tx['title']['validate']="Validate links";
 $tx['title']['xh_backups']="Backup";

--- a/tests/unit/PoweredByTest.php
+++ b/tests/unit/PoweredByTest.php
@@ -114,7 +114,7 @@ class PoweredByTest extends PHPUnit_Framework_TestCase
             array(
                 'tag' => 'a',
                 'attributes' => array('href' => 'http://cmsimple-xh.org'),
-                'content' => 'CMSimple_XH 1.7'
+                'content' => 'CMSimple_XH'
             ),
             XH_poweredBy()
         );
@@ -123,7 +123,7 @@ class PoweredByTest extends PHPUnit_Framework_TestCase
     public function testViewShowsTemplateInfo()
     {
         $this->assertStringMatchesFormat(
-            '%A<li>Mini1</li>%A',
+            '%A<dt>Mini1</dt>%A',
             XH_poweredBy()
         );
     }


### PR DESCRIPTION
We internationalize the generated content (except for the template
descriptions), and use a `<dl>` for the template list which is more
semantically meaningful.