### PR TITLE
Close #140: Combine all stylesheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 doc/
 tests/coverage/
 vendor/
-assets/css/plugins.css
+assets/css/stylesheet.css

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1710,7 +1710,7 @@ function XH_pluginStylesheet()
 
     $plugins = XH_plugins();
 
-    $ofn = $pth['folder']['corestyle'] . 'plugins.css';
+    $ofn = $pth['folder']['corestyle'] . 'stylesheet.css';
     $expired = !file_exists($ofn);
 
     // check for newly (un)installed plugins
@@ -1742,7 +1742,10 @@ function XH_pluginStylesheet()
 
     // create combined plugin stylesheet
     if ($expired) {
-        $o = array();
+        $o = array(
+            PHP_EOL . '/' . str_pad(' ' . $pth['file']['corestyle'], 76, '*', STR_PAD_LEFT) . ' */'
+            . PHP_EOL . PHP_EOL . file_get_contents($pth['file']['corestyle'])
+        );
         foreach ($plugins as $plugin) {
             $fn = $pth['folder']['plugins'] . $plugin . '/css/stylesheet.css';
             if (file_exists($fn)) {

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -85,8 +85,6 @@ function head()
         . CMSIMPLE_XH_BUILD . ' - www.cmsimple-xh.org">' . "\n"
         . '<!-- plugins: ' . $plugins . ' -->' . "\n"
         . XH_renderPrevLink() . XH_renderNextLink()
-        . '<link rel="stylesheet" href="' . $pth['file']['corestyle']
-        . '" type="text/css">' . "\n"
         . '<link rel="stylesheet" href="' . XH_pluginStylesheet()
         . '" type="text/css">' . PHP_EOL
         . '<link rel="stylesheet" href="' . $pth['file']['stylesheet']

--- a/plugins/filebrowser/tpl/editorbrowser.html
+++ b/plugins/filebrowser/tpl/editorbrowser.html
@@ -5,8 +5,7 @@ global $pth, $_XH_csrfProtection;
 <html lang="en">
     <head>
         <title>Filebrowser</title>
-        <link rel="stylesheet" href="<?php echo $pth['file']['corestyle']?>" type="text/css">
-        <link rel="stylesheet" href="<?php echo $pth['folder']['plugin_css']?>stylesheet.css" type="text/css">
+        <link rel="stylesheet" href="<?php echo "{$pth['folder']['corestyle']}stylesheet.css"?>" type="text/css">
         <style type="text/css">body {padding: 0; margin: 0; overflow: auto;}</style>
 
         %SCRIPT%

--- a/tests/unit/HeadTest.php
+++ b/tests/unit/HeadTest.php
@@ -189,26 +189,6 @@ class HeadTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests that the core stylesheet link element is rendered.
-     *
-     * @return void
-     */
-    public function testRendersCoreStylesheetLink()
-    {
-        @$this->assertTag(
-            array(
-                'tag' => 'link',
-                'attributes' => array(
-                    'rel' => 'stylesheet',
-                    'type' => 'text/css',
-                    'href' => 'corestyle'
-                )
-            ),
-            head()
-        );
-    }
-
-    /**
      * Tests that the prev link is rendered.
      *
      * @return void


### PR DESCRIPTION
As there are issues regarding the template stylesheets
(import-at-rules and/or multiple templates) we exclude them, but at
least we combine `core.css` and `plugins.css` in the file
`stylesheet.css`. This way we save one request, what's still a nice
improvement.

Instead of fixing the related unit test, we dump it because it relies
on the deprecated ::assertTag().