### PR TITLE
Close 203: Add API to access page name as plain text

### DIFF
--- a/cmsimple/classes/Pages.php
+++ b/cmsimple/classes/Pages.php
@@ -120,10 +120,31 @@ class Pages
      * @param int $n A page index.
      *
      * @return string
+     *
+     * @see name()
      */
     public function heading($n)
     {
         return $this->headings[$n];
+    }
+
+    /**
+     * Returns the name of a page.
+     *
+     * The name of a page is its heading sans any HTML tags, and with all HTML
+     * entities decoded, i.e. the plain text version of the heading.
+     *
+     * @param int $n A page index.
+     *
+     * @return string
+     *
+     * @see heading()
+     *
+     * @since 1.7
+     */
+    public function name($n)
+    {
+        return html_entity_decode(strip_tags($this->headings[$n]), ENT_QUOTES, 'UTF-8');
     }
 
     /**

--- a/tests/unit/PagesTest.php
+++ b/tests/unit/PagesTest.php
@@ -124,6 +124,17 @@ class PagesTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testName()
+    {
+        global $h;
+
+        for ($i = 0; $i < $this->_subject->getCount(); ++$i) {
+            $expected = html_entity_decode(strip_tags($h[$i]), ENT_QUOTES, 'UTF-8');
+            $actual = $this->_subject->name($i);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
     public function testUrl()
     {
         global $u;


### PR DESCRIPTION
We introduce `Pages::name()`.