### PR TITLE
Close #234: Get rid of global $rq variable

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -797,15 +797,14 @@ define('XH_CWD', getcwd());
  */
 $su = '';
 if (sv('QUERY_STRING') != '') {
-    // $rq should be $temp, but its used at least in tg_popup
-    $rq = explode('&', sv('QUERY_STRING'));
-    if (!strpos($rq[0], '=')) {
-        $su = $rq[0];
+    $j = explode('&', sv('QUERY_STRING'));
+    if (!strpos($j[0], '=')) {
+        $su = $j[0];
     }
     if ($su == '' && $selected != '') {
         $su = $selected;
     }
-    foreach ($rq as $i) {
+    foreach ($j as $i) {
         if (!strpos($i, '=') && in_array($i, $temp)) {
             $GLOBALS[$i] = 'true';
         }


### PR DESCRIPTION
As `$rq` isn't used elsewhere, and has never been documented as part of
the public API, we replace it with the temporary variable `$j` which is
meant for temporary purposes.