### PR TITLE
Close #19: Redirect `selected` GET requests to proper page URLs

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -803,7 +803,12 @@ if (sv('QUERY_STRING') != '') {
         $su = $rq[0];
     }
     if ($su == '' && $selected != '') {
-        $su = $selected;
+        if (isset($_GET['selected'])) {
+            header('Location: ' . XH_redirectSelectedUrl(), true, 301);
+            exit;
+        } else {
+            $su = $selected;
+        }
     }
     foreach ($rq as $i) {
         if (!strpos($i, '=') && in_array($i, $temp)) {

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2840,3 +2840,25 @@ function XH_getPageURL($index)
 
     return $sn . '?' . $u[$index];
 }
+
+/**
+ * Returns the URL where to redirect `selected` GEt requests.
+ *
+ * @return string
+ *
+ * @global string The value of the `selected` GP parameter.
+ *
+ * @since 1.7.0
+ */
+function XH_redirectSelectedUrl()
+{
+    global $selected;
+
+    $queryString = ltrim(preg_replace('/&?selected=[^&]+/', '', $_SERVER['QUERY_STRING']), '&');
+    if ($queryString) {
+        $queryString = "$selected&$queryString";
+    } else {
+        $queryString = $selected;
+    }
+    return CMSIMPLE_URL . "?$queryString";
+}

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -796,6 +796,44 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
             ]
         ];
     }
+
+    /**
+     * @dataProvider dataForRedirectSelectedUrl
+     * @param string $queryString
+     * @param string $expected
+     */
+    public function testRedirectSelectedUrl($queryString, $selected, $expected)
+    {
+        $this->redefineConstant('CMSIMPLE_URL', 'http://example.com/');
+        $GLOBALS['selected'] = $selected;
+        $_SERVER['QUERY_STRING'] = $queryString;
+        $this->assertSame($expected, XH_redirectSelectedUrl());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function dataForRedirectSelectedUrl()
+    {
+        return array(
+            ['selected=foo', 'foo', 'http://example.com/?foo'],
+            ['selected=foo&bar=baz', 'foo', 'http://example.com/?foo&bar=baz'],
+            ['foo=bar&selected=baz', 'baz', 'http://example.com/?baz&foo=bar'],
+            ['foo=bar&selected=baz&bar=foo', 'baz', 'http://example.com/?baz&foo=bar&bar=foo']
+        );
+    }
+
+    /**
+     * @param string $name
+     */
+    private function redefineConstant($name, $value)
+    {
+        if (!defined($name)) {
+            define($name, $value);
+        } else {
+            runkit_constant_redefine($name, $value);
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
We redirect incoming `selected` requests to their canonical page URL
with a "301 Moved Permanently" response.