### PR TITLE
Close #54: Search may generate superfluous output

### DIFF
--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -142,9 +142,15 @@ class Search
     {
         global $s;
 
+        $vars = array('s', 'o', 'hjs', 'bjs', 'e', 'onload');
+        foreach ($vars as $var) {
+            $old[$var] = $GLOBALS[$var];
+        }
         $s = $pageIndex;
         $content = strip_tags(evaluate_plugincall($content));
-        $s = -1;
+        foreach ($vars as $var) {
+            $GLOBALS[$var] = $old[$var];
+        }
         if (method_exists('\Normalizer', 'normalize')) {
             $content = \Normalizer::normalize($content);
         }

--- a/tests/unit/SearchTest.php
+++ b/tests/unit/SearchTest.php
@@ -28,7 +28,7 @@ class SearchTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        global $c, $cf;
+        global $c, $cf, $s, $o, $hjs, $bjs, $e, $onload;
 
         $c = array(
             '<h1>Welcome to CMSimple_XH</h1>',


### PR DESCRIPTION
The evaluation of plugin calls during the search is supposed to be
temporary only. Therefore we have to reset any potentially modified
global variables. It might be necessary to reset all globals and even
the superglobals, but we're sticking with a small set of the usual
suspects for now.