### PR TITLE
Close #243: Remove closing ?> tags from config and lang files

### DIFF
--- a/cmsimple/classes/CoreArrayFileEdit.php
+++ b/cmsimple/classes/CoreArrayFileEdit.php
@@ -59,7 +59,6 @@ abstract class CoreArrayFileEdit extends ArrayFileEdit
                 $o .= "\$$this->varName['$cat']['$name']=\"$opt\";\n";
             }
         }
-        $o .= "\n?>\n";
         return $o;
     }
 

--- a/cmsimple/classes/PluginArrayFileEdit.php
+++ b/cmsimple/classes/PluginArrayFileEdit.php
@@ -67,7 +67,6 @@ abstract class PluginArrayFileEdit extends ArrayFileEdit
                 $o .= "\$$this->varName['$this->plugin']['$key']=\"$opt\";\n";
             }
         }
-        $o .= "\n?>\n";
         return $o;
     }
 }

--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -47,5 +47,3 @@ $cf['title']['format']="{SITE} &ndash; {PAGE}";
 $cf['mode']['advanced']="";
 $cf['format']['date']="long";
 $cf['format']['time']="short";
-
-?>

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -332,5 +332,3 @@ $tx['validate']['intfilok']="INTERNE VERLINKUNG AUF DATEI OK";
 $tx['validate']['intok']="INTERNE VERLINKUNG OK";
 $tx['validate']['mailto']="MAILTO VERLINKUNG";
 $tx['validate']['notxt']="KEIN TEXT IN VERLINKUNG";
-
-?>

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -331,5 +331,3 @@ $tx['validate']['intfilok']="INTERNAL LINK TO FILE OK";
 $tx['validate']['intok']="INTERNAL LINK OK";
 $tx['validate']['mailto']="MAILTO LINK";
 $tx['validate']['notxt']="NO TEXT IN LINK";
-
-?>

--- a/cmsimple/languages/metade.php
+++ b/cmsimple/languages/metade.php
@@ -52,5 +52,3 @@ $mtx['uri']="URL";
 $mtx['urichar']="URL-Zeichen";
 $mtx['userfiles']="Benutzerdateien";
 $mtx['word separator']="Worttrennzeichen";
-
-?>

--- a/cmsimple/languages/metaen.php
+++ b/cmsimple/languages/metaen.php
@@ -4,5 +4,3 @@ $mtx['seperator']="Separator";
 $mtx['external']="Name";
 $mtx['org']="Original";
 $mtx['urichar']="URL-Characters";
-
-?>

--- a/index.php
+++ b/index.php
@@ -4,4 +4,3 @@ if (is_readable('./cmsimple/userprelude.php')) {
     include './cmsimple/userprelude.php';
 }
 include('./cmsimple/cms.php');
-?>

--- a/plugins/filebrowser/config/config.php
+++ b/plugins/filebrowser/config/config.php
@@ -4,5 +4,3 @@ $plugin_cf['filebrowser']['extensions_images']="gif, jpg, jpeg, png, svg";
 $plugin_cf['filebrowser']['extensions_downloads']="doc, odt, pdf, rar, txt, zip";
 $plugin_cf['filebrowser']['extensions_userfiles']="doc, flv, gif, jpg, jpeg, mp3, mp4, odt, pdf, png, rar, txt, svg, swf, webm, zip,\r\nogg,ogv";
 $plugin_cf['filebrowser']['extensions_media']="flv, mp3, mp4, swf, webm, ogg, ogv";
-
-?>

--- a/plugins/filebrowser/languages/de.php
+++ b/plugins/filebrowser/languages/de.php
@@ -42,5 +42,3 @@ $plugin_tx['filebrowser']['cf_extensions_images']="Listen Sie die im Bilder-Ordn
 $plugin_tx['filebrowser']['cf_extensions_downloads']="Listen Sie die im Downloads-Ordner erlaubten Dateiendungen - voneinander durch Kommas getrennt - auf. <b>*</b> dient als Platzhalter für alle Dateiendungen";
 $plugin_tx['filebrowser']['cf_extensions_userfiles']="Listen Sie die im  Anwenderdateien-Ordner erlaubten Dateiendungen - voneinander durch Kommas getrennt - auf. <b>*</b> dient als Platzhalter für alle Dateiendungen";
 $plugin_tx['filebrowser']['cf_extensions_media']="Listen Sie die im Media-Ordner erlaubten Dateiendungen - voneinander durch Kommas getrennt - auf. <b>*</b> dient als Platzhalter für alle Dateiendungen";
-
-?>

--- a/plugins/filebrowser/languages/en.php
+++ b/plugins/filebrowser/languages/en.php
@@ -42,5 +42,3 @@ $plugin_tx['filebrowser']['cf_extensions_images']="Fill in the file extensions y
 $plugin_tx['filebrowser']['cf_extensions_downloads']="Fill in the file extensions you want to allow for the downloads folder as comma separated list. <b>*</b> is a wildcard for all file extensions.";
 $plugin_tx['filebrowser']['cf_extensions_userfiles']="Fill in the file extensions you want to allow for the userfiles folder as comma separated list. <b>*</b> is a wildcard for all file extensions.";
 $plugin_tx['filebrowser']['cf_extensions_media']="Fill in the file extensions you want to allow for the media folder as comma separated list. <b>*</b> is a wildcard for all file extensions.";
-
-?>

--- a/plugins/page_params/languages/de.php
+++ b/plugins/page_params/languages/de.php
@@ -26,5 +26,3 @@ $plugin_tx['page_params']['hint_linked_to_menu']="<p>Wenn eine Seite nicht im Na
 $plugin_tx['page_params']['hint_last_edit']="<p>Sie können das Datum der letzten Bearbeitung anzeigen lassen.</p><p>Das Datumsformat legen Sie über die CMSimple-Spracheinstellungen fest, das sonstige Erscheinungsbild per CSS (#pp_last_update).</p>";
 $plugin_tx['page_params']['hint_template']="<p>Hier können Sie für diese Seite ein vom Standard abweichendes Template auswählen. Dieses Template gilt automatisch auch für Unterseiten dieser Seite.</p>";
 $plugin_tx['page_params']['hint_header_location']="<p>Hier kann die Seite auf ein internes oder externes Ziel weitergeleitet werden.</p><p>Externe Ziele mit Protokoll eintragen, z.B. http://...</p>";
-
-?>

--- a/plugins/page_params/languages/en.php
+++ b/plugins/page_params/languages/en.php
@@ -26,5 +26,3 @@ $plugin_tx['page_params']['hint_linked_to_menu']="<p>If unchecked, this page wil
 $plugin_tx['page_params']['hint_last_edit']="<p>Choose \"top\" or \"bottom\" to display the date of the last edit of this very page above resp. below the content. The Date format can be changed in the language settings, the look can be styled with the CSS selector <em>#pp_last_update</em>.</p>";
 $plugin_tx['page_params']['hint_template']="<p>Here you can select a special template for this page. All subpages of the page will also have this template.</p>";
 $plugin_tx['page_params']['hint_header_location']="<p>Here you can redirect this page to another internal or external page.</p><p>External targets have to be noted including the protocol (e.g. http://)</p>";
-
-?>

--- a/tests/attack/CSRFAttackTest.php
+++ b/tests/attack/CSRFAttackTest.php
@@ -223,5 +223,3 @@ class CSRFAttackTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(403, $actual);
     }
 }
-
-?>

--- a/tests/attack/DOSAttackTest.php
+++ b/tests/attack/DOSAttackTest.php
@@ -38,5 +38,3 @@ class DOSAttackTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 }
-
-?>

--- a/tests/attack/XSSAttackTest.php
+++ b/tests/attack/XSSAttackTest.php
@@ -38,5 +38,3 @@ class XSSAttackTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($condition);
     }
 }
-
-?>

--- a/tests/validation/ValidationTest.php
+++ b/tests/validation/ValidationTest.php
@@ -72,5 +72,3 @@ class ValidationTest extends TestCase
         $this->validate($html);
     }
 }
-
-?>


### PR DESCRIPTION
These are superfluous at best, and may cause malfunctions if followed
by more than a single line break, so we remove them. We also make sure
that they are not introduced back, if config or language files are
saved from the back-end.