### PR TITLE
Fix #166: $bjs missing from print preview

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1892,7 +1892,7 @@ function XH_title($site, $subtitle)
  */
 function XH_builtinTemplate($bodyClass)
 {
-    global $sl, $_XH_csrfProtection;
+    global $sl, $_XH_csrfProtection, $bjs;
 
     echo '<!DOCTYPE html>', "\n", '<html',
         (strlen($sl) == 2 ? " lang=\"$sl\"" : ''), '>', "\n";
@@ -1900,7 +1900,7 @@ function XH_builtinTemplate($bodyClass)
     echo '<head>', "\n" . head(),
         '<meta name="robots" content="noindex">', "\n",
         '</head>', "\n", '<body class="', $bodyClass,'"', onload(), '>', "\n",
-        $content, '</body>', "\n", '</html>', "\n";
+        $content, $bjs, '</body>', "\n", '</html>', "\n";
     if (isset($_XH_csrfProtection)) {
         $_XH_csrfProtection->store();
     }


### PR DESCRIPTION
It's not really clear, whether JS should be included in the print view,
but since $hjs is part of the print preview, $bjs should also be.