### PR TITLE
Close #242: Enforce or check that session.cookie_lifetime == 0

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -311,6 +311,9 @@ HTML;
         ini_get('session.use_only_cookies'), false, $stx['use_only_cookies']
     );
     $checks['other'][] = array(
+        ini_get('session.cookie_lifetime') == 0, false, $stx['cookie_lifetime']
+    );
+    $checks['other'][] = array(
         strpos(ob_get_contents(), "\xEF\xBB\xBF") !== 0,
         false, $stx['bom']
     );

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -267,6 +267,7 @@ $tx['submenu']['heading']="weiter zu:";
 
 $tx['syscheck']['access_protected']="'%s' zugriffsgeschützt ist";
 $tx['syscheck']['bom']="kein <a href=\"http://www.cmsimple-xh.org/wiki/doku.php/de:utf8#was_ist_ein_bom\" target=\"_blank\">BOM</a> vorhanden ist";
+$tx['syscheck']['cookie_lifetime']="session.cookie_lifetime 0 ist";
 $tx['syscheck']['extension']="die Erweiterung '%s' geladen ist";
 $tx['syscheck']['fail']="Fehler";
 $tx['syscheck']['fsockopen']="die Funktion fsockopen verfügbar ist";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -266,6 +266,7 @@ $tx['submenu']['heading']="Submenu";
 
 $tx['syscheck']['access_protected']="'%s' is access protected";
 $tx['syscheck']['bom']="there is no <a href=\"http://www.cmsimple-xh.org/wiki/doku.php/utf8#what_s_a_bom\" target=\"_blank\">BOM</a>";
+$tx['syscheck']['cookie_lifetime']="session.cookie_lifetime is 0";
 $tx['syscheck']['extension']="extension '%s' is loaded";
 $tx['syscheck']['fail']="failure";
 $tx['syscheck']['fsockopen']="function fsockopen is available";


### PR DESCRIPTION
`session.cookie_lifetime == 0` is only important in some countries, and
even there it might not be important at all, so we refrain from
enforcing this setting, but settle for a system check triggering a
warning otherwise.