### PR TITLE
Fix #252: Advanced mode config option lacks help text

### DIFF
--- a/cmsimple/metaconfig.php
+++ b/cmsimple/metaconfig.php
@@ -30,7 +30,7 @@ $mcf['menu']['sdoc']="enum:,parent";
 $mcf['uri']['length']="hidden";
 $mcf['editmenu']['scroll']="bool";
 $mcf['editmenu']['external']="xfunction:XH_registeredEditmenuPlugins";
-$mcf['mode']['advanced']="bool";
+$mcf['mode']['advanced']="hidden";
 $mcf['format']['date']="enum:none,short,medium,long,full";
 $mcf['format']['time']="enum:none,short,medium,long,full";
 


### PR DESCRIPTION
Instead of adding a help text and prominently announcing the advanced
mode, we hide this configuration option. After all, its meant for
advanced users only, who are supposed to be able edit config.php
manually, anyway.