### PR TITLE
Close #2: opendir() doesn't check that is_dir()

### DIFF
--- a/cmsimple/classes/Backup.php
+++ b/cmsimple/classes/Backup.php
@@ -120,7 +120,7 @@ class Backup
     private function findBackups()
     {
         $result = array();
-        if ($dir = opendir($this->contentFolder)) {
+        if (is_dir($this->contentFolder) && ($dir = opendir($this->contentFolder))) {
             while (($entry = readdir($dir)) !== false) {
                 if (XH_isContentBackup($entry)) {
                     $result[] = $entry;

--- a/cmsimple/classes/CoreArrayFileEdit.php
+++ b/cmsimple/classes/CoreArrayFileEdit.php
@@ -78,7 +78,7 @@ abstract class CoreArrayFileEdit extends ArrayFileEdit
         global $pth;
 
         $options = array();
-        if ($dh = opendir($pth['folder'][$fn])) {
+        if (is_dir($pth['folder'][$fn]) && ($dh = opendir($pth['folder'][$fn]))) {
             while (($p = readdir($dh)) !== false) {
                 if (preg_match($regex, $p, $m)) {
                     $options[] = $m[1];

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1054,7 +1054,7 @@ function XH_uenc($s, array $search, array $replace)
  *
  * Caveat: the result includes '.' and '..'.
  *
- * @param string $dir The directory path.
+ * @param string $dir An existing directory path.
  *
  * @return array
  */
@@ -1449,7 +1449,7 @@ function XH_plugins($admin = false)
         $admPlugins = array();
         $disabledPlugins = explode(',', $cf['plugins']['disabled']);
         $disabledPlugins = array_map('trim', $disabledPlugins);
-        if ($dh = opendir($pth['folder']['plugins'])) {
+        if (is_dir($pth['folder']['plugins']) && ($dh = opendir($pth['folder']['plugins']))) {
             while (($fn = readdir($dh)) !== false) {
                 if (strpos($fn, '.') !== 0
                     && is_dir($pth['folder']['plugins'] . $fn)
@@ -1964,7 +1964,7 @@ function XH_templates()
     global $pth;
 
     $templates = array();
-    if ($handle = opendir($pth['folder']['templates'])) {
+    if (is_dir($pth['folder']['templates']) && ($handle = opendir($pth['folder']['templates']))) {
         while (($file = readdir($handle)) !== false) {
             $dir = $pth['folder']['templates'] . $file;
             if ($file[0] != '.' && is_dir($dir)
@@ -1993,7 +1993,7 @@ function XH_availableLocalizations()
     global $pth;
 
     $languages = array();
-    if ($handle = opendir($pth['folder']['language'])) {
+    if (is_dir($pth['folder']['language']) && ($handle = opendir($pth['folder']['language']))) {
         while (($file = readdir($handle)) !== false) {
             if (preg_match('/^([a-z]{2})\.php$/i', $file, $m)) {
                 $languages[] = $m[1];
@@ -2023,7 +2023,7 @@ function XH_secondLanguages()
 
     if (!isset($langs)) {
         $langs = array();
-        if ($dir = opendir($pth['folder']['base'])) {
+        if (is_dir($pth['folder']['base']) && ($dir = opendir($pth['folder']['base']))) {
             while (($entry = readdir($dir)) !== false) {
                 if ($entry[0] != '.' && XH_isLanguageFolder($entry)) {
                     $langs[] = $entry;

--- a/plugins/filebrowser/classes/Controller.php
+++ b/plugins/filebrowser/classes/Controller.php
@@ -254,8 +254,7 @@ class Controller
         $dir = $this->browseBase . $this->currentDirectory;
         $this->files = array();
 
-        $handle = opendir($dir);
-        if ($handle) {
+        if (is_dir($dir) && ($handle = opendir($dir))) {
             while (false !== ($file = readdir($handle))) {
                 if (strpos($file, '.') === 0) {
                     continue;
@@ -285,8 +284,7 @@ class Controller
     private function getFolders($directory)
     {
         $folders = array();
-        $handle = opendir($directory);
-        if ($handle) {
+        if (is_dir($directory) && ($handle = opendir($directory))) {
             while (false !== ($file = readdir($handle))) {
                 if (strpos($file, '.') === 0) {
                     continue;
@@ -571,7 +569,7 @@ class Controller
     private function isEmpty($folder)
     {
         $isEmpty = true;
-        if ($dir = opendir($folder)) {
+        if (is_dir($folder) && ($dir = opendir($folder))) {
             while (($entry = readdir($dir)) !== false) {
                 if ($entry != '.' && $entry != '..') {
                     $isEmpty = false;


### PR DESCRIPTION
We guard all `opendir()` calls in the core and internal plugins with an
explicit check that `is_dir()` to make that more resilient. The only
case which we don't guard is in `sortdir()`, where we document that the
directory is supposed to exist.