### PR TITLE
Fix #251: TinyMCE: some languages are not recognized

### DIFF
--- a/plugins/tinymce4/tinymce/langs/fr.js
+++ b/plugins/tinymce4/tinymce/langs/fr.js
@@ -1,4 +1,4 @@
-tinymce.addI18n('fr_FR',{
+tinymce.addI18n('fr',{
 "Cut": "Couper",
 "Heading 5": "En-t\u00eate 5",
 "Header 2": "Titre 2",

--- a/plugins/tinymce4/tinymce/langs/tw.js
+++ b/plugins/tinymce4/tinymce/langs/tw.js
@@ -1,4 +1,4 @@
-tinymce.addI18n('zh_TW',{
+tinymce.addI18n('tw',{
 "Cut": "\u526a\u4e0b",
 "Heading 5": "\u6a19\u984c 5",
 "Header 2": "\u6a19\u984c 2",

--- a/plugins/tinymce4/tinymce/langs/zh.js
+++ b/plugins/tinymce4/tinymce/langs/zh.js
@@ -1,4 +1,4 @@
-tinymce.addI18n('zh_CN',{
+tinymce.addI18n('zh',{
 "Cut": "\u526a\u5207",
 "Heading 5": "\u6807\u98985",
 "Header 2": "\u6807\u98982",


### PR DESCRIPTION
As quick fix we rename the i18n keys to match the files they're
contained in. This has to be done again for each TinyMCE update, or a
better solution would be needed in the future.