### PR TITLE
Line145 . ---> .secmenu span :not(.newsin)

### DIFF
--- a/templates/fhs-simple/navi.css
+++ b/templates/fhs-simple/navi.css
@@ -142,7 +142,7 @@
 	display: block;
 	border-top: 1px dotted #ccc;
 }
-.secmenu span {
+.secmenu span :not(.newsin) {
 	padding: .5em .5em .5em 1em;
 	display: block;
 	background: rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Text color (span tag) is not displayed correctly in News BOX.

 .secmenu span ---> .secmenu span :not(.newsin) 

![navi_css line145](https://user-images.githubusercontent.com/14984349/29754654-991c7190-8bc4-11e7-9de0-a25d6d46c898.gif)
