### PR TITLE
Fix #278: Catchable fatal errors are handled inconsistently

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1274,6 +1274,9 @@ function XH_debug($errno, $errstr, $errfile, $errline)
             $errfile = $backtrace[2]['file'];
             $errline = $backtrace[2]['line'];
             break;
+        case E_RECOVERABLE_ERROR:
+            $errtype = 'ERROR';
+            break;
         case E_WARNING:
             $errtype = 'WARNING';
             break;
@@ -1293,7 +1296,7 @@ function XH_debug($errno, $errstr, $errfile, $errline)
     $errors[] = "<b>$errtype:</b> $errstr" . '<br>' . "$errfile:$errline"
         . '<br>' . "\n";
 
-    if ($errno === E_USER_ERROR) {
+    if (in_array($errno, [E_USER_ERROR, E_RECOVERABLE_ERROR])) {
         XH_exit($errors[count($errors) - 1]);
     }
 

--- a/tests/unit/ErrorHandlerTest.php
+++ b/tests/unit/ErrorHandlerTest.php
@@ -55,6 +55,7 @@ class ErrorHandlerTest extends TestCase
     public function provideDataForErrorTest()
     {
         return array(
+            [E_RECOVERABLE_ERROR, 'ERROR'],
             [E_USER_ERROR, 'XH-ERROR']
         );
     }


### PR DESCRIPTION
We are not convinced that ignoring recoverable (formerly called
catchable) errors (`E_RECOVERABLE_ERROR`) is a good idea, generally.
Furthermore, to do so would require a general error handler (opposed to
our long standing debug mode handler). Therefore we decide to treat
recoverable errors just like user errors (E_USER_ERROR), i.e. to bail
out whenever they occur.

We changing the call to `die()` to `XH_exit()` to be able to mock the
function in a respective test.