### PR TITLE
Fix #281: Multiple consecutive newlines in content are removed

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -946,7 +946,7 @@ function XH_saveContents()
         preg_match("/(.*?)($hot(.+?)$hct)(.*)/isu", $i, $matches);
         $page = $matches[1] . $matches[2] . PHP_EOL . $pd_router->pageAsPHP($j)
             . $matches[4];
-        $cnts .= rmnl($page . "\n");
+        $cnts .= rtrim($page, "\r\n") . "\n";
     }
     $cnts .= '</body></html>';
     if (!file_exists($pth['folder']['content'])) {


### PR DESCRIPTION
To avoid removing multiple consecutive newlines in `<pre>` elements, we
do not remove them altogether anymore, except at the end of the page
content.