### PR TITLE
Do not explicitly document @globals and @staticvars of functions

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -22,8 +22,6 @@
  *
  * @return string
  *
- * @global array The paths of system files and folders.
- *
  * @since 1.6
  */
 function XH_pluginVersion($plugin)
@@ -52,8 +50,6 @@ function XH_pluginVersion($plugin)
  * Returns the result view of the system check.
  *
  * @param array $data The data ;)
- *
- * @global array The localization of the core.
  *
  * @return string HTML
  *
@@ -127,8 +123,6 @@ function XH_systemCheck(array $data)
  * @param string $state A state.
  * @param string $text  A message text.
  *
- * @global array The localization of the core.
- *
  * @return string
  *
  * @since 1.7.0
@@ -149,8 +143,6 @@ function XH_systemCheckLi($class, $state, $text)
  * @param string $path A relative path.
  *
  * @return string
- *
- * @global string The script name.
  *
  * @since 1.6.1
  */
@@ -205,11 +197,6 @@ function XH_isAccessProtected($path)
 
 /**
  * Returns the system information view.
- *
- * @global array           The paths of system files and folders.
- * @global array           The configuration of the core.
- * @global array           The localization of the core.
- * @global string The script name.
  *
  * @return string HTML
  *
@@ -336,9 +323,6 @@ HTML;
  *
  * @return string HTML
  *
- * @global string The script name.
- * @global array  The localization of the core.
- *
  * @since 1.6
  */
 function XH_settingsView()
@@ -383,10 +367,6 @@ function XH_settingsView()
  *
  * @return string HTML
  *
- * @global array  The paths of system files and folders.
- * @global array  The localization of the core.
- * @global string The title of the current page.
- *
  * @since 1.6
  */
 function XH_logFileView()
@@ -416,11 +396,6 @@ function XH_logFileView()
  * Returns the backup view.
  *
  * @return string HTML
- *
- * @global array  The paths of system files and folders.
- * @global array  The script name.
- * @global array  The localization of the core.
- * @global object The CSRF protection object.
  *
  * @since 1.6
  */
@@ -487,10 +462,6 @@ function XH_backupsView()
  *
  * @return string HTML
  *
- * @global array  The script name.
- * @global array  The configuration of the core
- * @global array  The localization of the core.
- *
  * @since 1.7
  */
 function XH_pluginsView()
@@ -529,8 +500,6 @@ function XH_pluginsView()
  * @param array  $style  Array with style-data for the containing table-cell
  *
  * @return mixed
- *
- * @global XH\ClassicPluginMenu The plugin menu builder.
  */
 function pluginMenu($add = '', $link = '', $target = '', $text = '', array $style = array())
 {
@@ -578,8 +547,6 @@ function XH_registerStandardPluginMenuItems($showMain)
  *
  * @return mixed
  *
- * @staticvar array $pluginMenu The array of already registered menu items.
- *
  * @since 1.6.2
  */
 function XH_registerPluginMenuItem($plugin, $label = null, $url = null, $target = null)
@@ -607,15 +574,6 @@ function XH_registerPluginMenuItem($plugin, $label = null, $url = null, $target 
  * @param array $plugins A list of plugins.
  *
  * @return string HTML
- *
- * @global string The scipt name.
- * @global bool   Whether edit mode is active.
- * @global int    The index of the current page.
- * @global array  The URLs of the pages.
- * @global array  The configuration of the core.
- * @global array  The localization of the core.
- * @global string The URL of the current page.
- * @global array  The localization of the plugins.
  *
  * @since 1.6
  */
@@ -806,8 +764,6 @@ function XH_adminMenuItem(array $item, $level = 0)
  *                     ('ON'/'OFF').
  *
  * @return string HTML
- *
- * @global XH\ClassicPluginMenu The plugin menu builder.
  */
 function print_plugin_admin($main)
 {
@@ -819,9 +775,6 @@ function print_plugin_admin($main)
 /**
  * Handles reading and writing of plugin files
  * (e.g. en.php, config.php, stylesheet.css).
- *
- * @global string The requested action.
- * @global string The requested admin-action.
  *
  * @return string Returns the created form or the result of saving the data.
  */
@@ -857,16 +810,6 @@ function plugin_admin_common()
 
 /**
  * Returns the content editor and activates it.
- *
- * @global string The script name.
- * @global string The currently active page URL.
- * @global int    The index of the currently active page.
- * @global array  The URLs of the pages.
- * @global array  The content of the pages.
- * @global string Error messages as HTML fragment consisting of LI Elements.
- * @global array  The configuration of the core.
- * @global array  The localization of the core.
- * @global object The CSRF protection object.
  *
  * @return string  HTML
  *
@@ -917,12 +860,6 @@ function XH_contentEditor()
  *
  * @return bool Whether that succeeded
  *
- * @global array  The content of the pages.
- * @global array  The paths of system files and folders.
- * @global array  The localization of the core.
- * @global array  Whether edit mode is active.
- * @global object The page data router.
- *
  * @since 1.6
  */
 function XH_saveContents()
@@ -959,15 +896,6 @@ function XH_saveContents()
  * Saves content.htm after submitting changes from the content editor.
  *
  * @param string $text The text to save.
- *
- * @global array  The paths of system files and folders.
- * @global array  The configuation of the core.
- * @global array  The localization of the core.
- * @global object The page data router.
- * @global array  The content of the pages.
- * @global int    The index of the active page.
- * @global array  The URLs of the pages.
- * @global string The URL of the active page.
  *
  * @return void
  *
@@ -1039,12 +967,6 @@ function XH_saveEditorContents($text)
  * Empties the contents.
  *
  * @return void
- *
- * @global array  The content of the pages.
- * @global int    The number of pages.
- * @global array  The paths of system files and folders.
- * @global array  An HTML fragment with error messages.
- * @global object The pagedata router.
  */
 function XH_emptyContents()
 {
@@ -1074,9 +996,6 @@ function XH_emptyContents()
  * @param string $filename The filename.
  *
  * @return void
- *
- * @global array  The paths of system files and folders.
- * @global array  An HTML fragment with error messages.
  *
  * @since 1.6
  */
@@ -1134,8 +1053,6 @@ function XH_extraBackup($suffix)
  * Returns SCRIPT element containing the localization for admin.min.js.
  *
  * @return string HTML
- *
- * @global array The localization of the core.
  *
  * @since 1.6
  */

--- a/cmsimple/classes/ArrayFileEdit.php
+++ b/cmsimple/classes/ArrayFileEdit.php
@@ -146,8 +146,6 @@ abstract class ArrayFileEdit extends FileEdit
      * @param array  $opt  The field options.
      *
      * @return string HTML
-     *
-     * @global array The localization of the core.
      */
     protected function formField($cat, $name, array $opt)
     {
@@ -206,11 +204,6 @@ abstract class ArrayFileEdit extends FileEdit
      * Returns the form to edit the file contents.
      *
      * @return string HTML
-     *
-     * @global string The script name.
-     * @global array  The localization of the core.
-     * @global string The title of the current page.
-     * @global object The CSRF protection object.
      */
     public function form()
     {
@@ -298,9 +291,6 @@ abstract class ArrayFileEdit extends FileEdit
      * Otherwise writes an error message to $e, and returns the edit form.
      *
      * @return string HTML
-     *
-     * @global string Error messages.
-     * @global object The CSRF protection object.
      */
     public function submit()
     {

--- a/cmsimple/classes/Backup.php
+++ b/cmsimple/classes/Backup.php
@@ -60,8 +60,6 @@ class Backup
      * Initializes a new instance.
      *
      * @param array $contentFolders An array of foldernames.
-     *
-     * @global array The configuration of the core.
      */
     public function __construct(array $contentFolders)
     {
@@ -202,8 +200,6 @@ class Backup
      * @param string $filename A filename.
      *
      * @return string HTML
-     *
-     * @global array The localization of the core.
      */
     private function renderCreationInfo($filename)
     {
@@ -239,8 +235,6 @@ class Backup
      * @param string $filename A filename.
      *
      * @return string HTML
-     *
-     * @global array The localization of the core.
      */
     private function renderDeletionInfo($filename)
     {

--- a/cmsimple/classes/ChangePassword.php
+++ b/cmsimple/classes/ChangePassword.php
@@ -71,8 +71,6 @@ class ChangePassword
 
     /**
      * Initializes a new instance.
-     *
-     * @global CSRFProtection The CSRF protector.
      */
     public function __construct()
     {
@@ -92,8 +90,6 @@ class ChangePassword
     /**
      * Process the default action.
      *
-     * @global string The HTML of the contents area.
-     *
      * @return void
      */
     public function defaultAction()
@@ -105,8 +101,6 @@ class ChangePassword
 
     /**
      * Renders the change password form.
-     *
-     * @global string The site name.
      *
      * @return string
      */
@@ -163,8 +157,6 @@ class ChangePassword
     /**
      * Process the save action.
      *
-     * @global string The HTML of the contents area.
-     *
      * @return void
      */
     public function saveAction()
@@ -216,8 +208,6 @@ class ChangePassword
 
     /**
      * Saves the configuration with the new password hash.
-     *
-     * @global array The paths of system files and folders.
      *
      * @return bool
      */

--- a/cmsimple/classes/Controller.php
+++ b/cmsimple/classes/Controller.php
@@ -32,10 +32,6 @@ class Controller
      * Initializes the paths related to the template.
      *
      * @return void
-     *
-     * @global array The paths of system files and folders.
-     * @global array The configuration of the core.
-     * @global array The localization of the core.
      */
     public function initTemplatePaths()
     {
@@ -57,11 +53,6 @@ class Controller
      * Handles search requests.
      *
      * @return void
-     *
-     * @global array  The paths of system files and folders.
-     * @global array  The localization of the core.
-     * @global string The content of the title element.
-     * @global string The HTML of the contents area.
      */
     public function handleSearch()
     {
@@ -81,8 +72,6 @@ class Controller
      * Makes and returns a search object.
      *
      * @return Search
-     *
-     * @global string The search string.
      */
     public function makeSearch()
     {
@@ -95,11 +84,6 @@ class Controller
      * Handles mailform requests.
      *
      * @return void
-     *
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
-     * @global string The content of the title element.
-     * @global string The HTML of the contents area.
      */
     public function handleMailform()
     {
@@ -131,12 +115,6 @@ class Controller
      * Handles sitemap requests.
      *
      * @return void
-     *
-     * @global int    The number of pages.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
-     * @global string The content of the title element.
-     * @global string The HTML of the content area.
      *
      * @todo Declare visibility.
      */
@@ -180,12 +158,6 @@ class Controller
      * Handles login and logout.
      *
      * @return void
-     *
-     * @global string Whether admin mode is active.
-     * @global string Whether login is requested.
-     * @global string Whether logout is requested.
-     * @global string The admin password.
-     * @global string The requested function.
      */
     public function handleLoginAndLogout()
     {
@@ -209,12 +181,6 @@ class Controller
      * Handles login requests.
      *
      * @return void
-     *
-     * @global string       The requested function.
-     * @global array        The paths of system files and folders.
-     * @global string       The admin password.
-     * @global string       Whether login is requested.
-     * @global array        The configuration of the core.
      */
     public function handleLogin()
     {
@@ -243,12 +209,6 @@ class Controller
      * Handles logout requests.
      *
      * @return void
-     *
-     * @global string Whether admin mode is active.
-     * @global string The requested function.
-     * @global string Whether logout is requested.
-     * @global array  The localization of the core.
-     * @global string The HTML for the contents area.
      */
     public function handleLogout()
     {
@@ -282,13 +242,6 @@ class Controller
      * Sets frontend $f.
      *
      * @return void
-     *
-     * @global string The requested function.
-     * @global string The URL of the current page.
-     * @global string Whether the mailform is requested.
-     * @global string Whether the sitemap is requested.
-     * @global string Whether the page manager is requested.
-     * @global string The requested function.
      */
     public function setFrontendF()
     {
@@ -313,23 +266,6 @@ class Controller
      * Sets backend $f.
      *
      * @return void
-     *
-     * @global string The requested function.
-     * @global string Whether the link check is requested.
-     * @global string Whether the actual link check is requested.
-     * @global string Whether the settings page is requested.
-     * @global string Whether the backup page is requested.
-     * @global string Whether the pagedata editor is requested.
-     * @global string Whether the system info is requested.
-     * @global string Whether the PHP info is requested.
-     * @global string The name of a special file to be handled.
-     * @global string Whether the file browser is requested to show the
-     *                userfiles folder.
-     * @global string Whether the file browser is requested to show the image
-     *                folder.
-     * @global string Whether the file browser is requested to show the download
-     *                folder.
-     * @global string The requested function.
      *
      * @todo Handling of userfiles, images and downloads is probably not
      *       necessary, as this should already be handled by the filebrowser.
@@ -376,8 +312,6 @@ class Controller
      * Returns whether page data have to be saved.
      *
      * @return bool
-     *
-     * @global int The number of the current page.
      */
     public function wantsSavePageData()
     {
@@ -390,12 +324,6 @@ class Controller
      * Handles save page data requests.
      *
      * @return void
-     *
-     * @global array          The paths of system files and folders.
-     * @global int            The index of the currently selected page.
-     * @global PageDataRouter The page data router.
-     * @global array          The localization of the core.
-     * @global CSRFProtection The CSRF protector.
      */
     public function handleSavePageData()
     {
@@ -426,8 +354,6 @@ class Controller
      *
      * @return void
      *
-     * @global string The HTML for the contents area.
-     *
      * @todo Unused?
      */
     public function handlePagedataEditor()
@@ -452,10 +378,6 @@ class Controller
      * Handles file view requests.
      *
      * @return void
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The name of a special file to be handled.
-     * @global string The HTML for the contents area.
      */
     public function handleFileView()
     {
@@ -474,9 +396,6 @@ class Controller
      * Handles file backup requests.
      *
      * @return void
-     *
-     * @global string         The name of a special file to be handled.
-     * @global CSRFProtection The CRSF protector.
      */
     public function handleFileBackup()
     {
@@ -495,10 +414,6 @@ class Controller
      * Handles file edit requests.
      *
      * @return void
-     *
-     * @global string The name of a special file to be handled.
-     * @global string The requested action.
-     * @global string The HTML for the contents area.
      */
     public function handleFileEdit()
     {
@@ -537,9 +452,6 @@ class Controller
      * Outputs administration script elements.
      *
      * @return void
-     *
-     * @global array  The localization of the core.
-     * @global string The HTML for the contents area.
      */
     public function outputAdminScripts()
     {
@@ -568,9 +480,6 @@ EOT;
      * Sets functions as permitted.
      *
      * @return void
-     *
-     * @global string Whether edit mode is requested.
-     * @global string Whether normal mode is requested.
      *
      * @todo Rename!
      */
@@ -602,9 +511,6 @@ EOT;
      * Handles save requests.
      *
      * @return void
-     *
-     * @global string         The text of the editor on save.
-     * @global CSRFProtection The CSRF protector.
      */
     public function handleSaveRequest()
     {
@@ -618,10 +524,6 @@ EOT;
      * Whether edit mode is requested and the edit contents shall be displayed.
      *
      * @return bool
-     *
-     * @global string Whether edit mode is requested.
-     * @global string The requested function.
-     * @global string The filename requested for download.
      *
      * @todo Do we need $f == 'save' && !$download?
      *       IOW: isn't the script already exited in these cases?
@@ -637,10 +539,6 @@ EOT;
      * Outputs the edit contents (either editor or cntlocateheading).
      *
      * @return void
-     *
-     * @global int    The index of the currently selected page.
-     * @global array  The localization of the core.
-     * @global string The HTML for the contents area.
      */
     public function outputEditContents()
     {
@@ -668,8 +566,6 @@ EOT;
      * Returns whether the page manager is missing.
      *
      * @return bool
-     *
-     * @global string The requested function.
      */
     public function isPagemanagerMissing()
     {
@@ -683,16 +579,6 @@ EOT;
      * Returns whether the filebrowser is needed.
      *
      * @return bool
-     *
-     * @global string Whether the file browser is requested to show the image folder.
-     * @global string Whether the file browser is requested to show the download
-     *                folder.
-     * @global string Whether the file browser is requested to show the userfiles
-     *                folder.
-     * @global string Whether the file browser is requested to show the media folder.
-     * @global string Whether edit mode is requested.
-     * @global string The requested function.
-     * @global string The filename requested for download.
      *
      * @todo Do we need $f == 'save' && !$download?
      *       IOW: isn't the script already exited in these cases?
@@ -711,9 +597,6 @@ EOT;
      * @param string $name A plugin name ("filebrowser" or "pagemanager").
      *
      * @return bool
-     *
-     * @global array The paths of system files and folders.
-     * @global array The configuration of the core.
      */
     private function isExternalMissing($name)
     {
@@ -729,10 +612,6 @@ EOT;
      * @param string $name A plugin name ("filebrowser" or "pagemanger").
      *
      * @return bool
-     *
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
-     * @global string The HTML for the <li>s holding error messages.
      */
     public function reportMissingExternal($name)
     {
@@ -749,14 +628,6 @@ EOT;
      * may result in an infinite loop, so we do it this way.
      *
      * @return void
-     *
-     * @global bool   Whether we're logged in as administrator.
-     * @global bool   Whether we're in edit mode.
-     * @global array  The localization of the core.
-     * @global int    The current page.
-     * @global string The HTML fragment for insertion in the contents area.
-     * @global string The current special function.
-     * @global string The title of the page.
      */
     public function verifyAdm()
     {
@@ -776,8 +647,6 @@ EOT;
      * Renders the error messages stored in $e.
      *
      * @return string HTML
-     *
-     * @global string The HTML for the <li>s holding error messages.
      */
     public function renderErrorMessages()
     {
@@ -798,10 +667,6 @@ EOT;
      * is aborted.
      *
      * @return void
-     *
-     * @global string The ISO 659-1 code of the current language.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
      *
      * @todo Emit error message only in admin mode?
      */

--- a/cmsimple/classes/CoreArrayFileEdit.php
+++ b/cmsimple/classes/CoreArrayFileEdit.php
@@ -29,11 +29,6 @@ abstract class CoreArrayFileEdit extends ArrayFileEdit
 {
     /**
      * Constructs an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The current language.
-     * @global string The key of the system file.
-     * @global array  The localization of the plugins.
      */
     public function __construct()
     {
@@ -69,8 +64,6 @@ abstract class CoreArrayFileEdit extends ArrayFileEdit
      * @param string $regex The regex the filename must match.
      *
      * @return array
-     *
-     * @global array The paths of system files and folders.
      */
     protected function selectOptions($fn, $regex)
     {

--- a/cmsimple/classes/CoreConfigFileEdit.php
+++ b/cmsimple/classes/CoreConfigFileEdit.php
@@ -29,10 +29,6 @@ class CoreConfigFileEdit extends CoreArrayFileEdit
 {
     /**
      * Constructs an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
      */
     public function __construct()
     {

--- a/cmsimple/classes/CoreLangFileEdit.php
+++ b/cmsimple/classes/CoreLangFileEdit.php
@@ -29,10 +29,6 @@ class CoreLangFileEdit extends CoreArrayFileEdit
 {
     /**
      * Constructs an instance.
-     *
-     * @global string The current language.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
      */
     public function __construct()
     {

--- a/cmsimple/classes/CoreTextFileEdit.php
+++ b/cmsimple/classes/CoreTextFileEdit.php
@@ -29,10 +29,6 @@ class CoreTextFileEdit extends TextFileEdit
 {
     /**
      * Construct an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The requested special file.
-     * @global array  The localization of the core.
      */
     public function __construct()
     {

--- a/cmsimple/classes/Li.php
+++ b/cmsimple/classes/Li.php
@@ -70,8 +70,6 @@ class Li
      * @param mixed $st The menu level to start with or the type of menu.
      *
      * @return string HTML
-     *
-     * @global int The index of the current page.
      */
     public function render(array $ta, $st)
     {
@@ -160,8 +158,6 @@ class Li
      * @param int $i The index of the current item.
      *
      * @return int
-     *
-     * @global array  The menu levels of the pages.
      */
     protected function getMenuLevel($i)
     {
@@ -176,8 +172,6 @@ class Li
      * @param int $i The index of the current item.
      *
      * @return string
-     *
-     * @global array  The configuration of the core.
      */
     protected function getClassName($i)
     {
@@ -214,11 +208,6 @@ class Li
      * @param int $i The index of the current item.
      *
      * @return bool
-     *
-     * @global int    The index of the current page.
-     * @global array  The URLs of the pages.
-     * @global array  The menu levels of the pages.
-     * @global array  The configuration of the core.
      */
     protected function isAnchestorOfSelectedPage($i)
     {
@@ -235,10 +224,6 @@ class Li
      * @param int $i The index of the current item.
      *
      * @return bool
-     *
-     * @global int    The number of pages.
-     * @global array  The menu levels of the pages.
-     * @global array  The configuration of the core.
      */
     protected function hasChildren($i)
     {
@@ -263,8 +248,6 @@ class Li
      * @param int $i The index of the current item.
      *
      * @return string HTML
-     *
-     * @global array  The headings of the pages.
      */
     protected function renderMenuItem($i)
     {
@@ -303,9 +286,6 @@ class Li
      * @param int $i The index of the current item.
      *
      * @return bool
-     *
-     * @global array  Whether we are in edit mode.
-     * @global object The page data router.
      */
     protected function shallOpenInNewWindow($i)
     {

--- a/cmsimple/classes/LinkChecker.php
+++ b/cmsimple/classes/LinkChecker.php
@@ -33,10 +33,6 @@ class LinkChecker
      * Prepares the link check.
      *
      * @return string HTML
-     *
-     * @global string The script name.
-     * @global array  The paths of system files and folders.
-     * @global array  The localization of the core.
      */
     public function prepare()
     {
@@ -94,10 +90,6 @@ class LinkChecker
      * Gathers all links in the content and returns the result.
      *
      * @return array
-     *
-     * @global array The page contents.
-     * @global array The page URLs.
-     * @global int   The number of pages.
      */
     private function gatherLinks()
     {
@@ -170,12 +162,6 @@ class LinkChecker
      * @param array $test URL parts.
      *
      * @return string
-     *
-     * @global array The content of the pages.
-     * @global array The URLs of the pages.
-     * @global int   The number of pages.
-     * @global array The paths of system files and folders.
-     * @global array The configuration of the core.
      */
     private function checkInternalLink(array $test)
     {
@@ -369,10 +355,6 @@ class LinkChecker
      * @param array $hints        The errors and warnings.
      *
      * @return string HTML
-     *
-     * @global array The localization of the core.
-     * @global array The page headings.
-     * @global array The page URLs.
      */
     public function message($checkedLinks, array $hints)
     {

--- a/cmsimple/classes/Mail.php
+++ b/cmsimple/classes/Mail.php
@@ -64,8 +64,6 @@ class Mail
 
     /**
      * Initializes a new instance.
-     *
-     * @global array The configuration of the core.
      */
     public function __construct()
     {

--- a/cmsimple/classes/Mailform.php
+++ b/cmsimple/classes/Mailform.php
@@ -98,8 +98,6 @@ class Mailform
      * @param string $subject  An alternative subject field preset text instead of
      *                         the subject default in localization.
      * @param Mail   $mail     A mail object.
-     *
-     * @global array The localization of the core.
      */
     public function __construct($embedded = false, $subject = null, $mail = null)
     {
@@ -141,9 +139,6 @@ class Mailform
      * Returns error messages resp. an empty string if everything is okay.
      *
      * @return string HTML
-     *
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
      */
     public function check()
     {
@@ -168,9 +163,6 @@ class Mailform
      * Submits the mailform and returns whether that succeeded.
      *
      * @return bool
-     *
-     * @global array The configuration of the core.
-     * @global array The localization of the core.
      */
     public function submit()
     {
@@ -196,11 +188,6 @@ class Mailform
      * Processes the mailform request and returns the resulting view.
      *
      * @return string HTML
-     *
-     * @global string The requested action.
-     * @global array  The localization of the core.
-     *
-     * @staticvar bool Whether any mailform is processed more than once.
      *
      * @todo Remove static variable for better testability.
      */
@@ -233,11 +220,6 @@ class Mailform
      * Returns the mailform view.
      *
      * @return string HTML
-     *
-     * @global string The script name.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
-     * @global string The current page URL.
      */
     public function render()
     {

--- a/cmsimple/classes/PageDataEditor.php
+++ b/cmsimple/classes/PageDataEditor.php
@@ -29,8 +29,6 @@ class PageDataEditor
      * Returns the currently unused page data fields.
      *
      * @return array
-     *
-     * @global object The page data router.
      */
     private function unusedFields()
     {
@@ -49,8 +47,6 @@ class PageDataEditor
      * false if saving failed.
      *
      * @return int
-     *
-     * @global object The page data router.
      */
     private function deleteFields()
     {
@@ -89,9 +85,6 @@ class PageDataEditor
      *                       <var>false</var> on failure.
      *
      * @return string HTML
-     *
-     * @global array The paths of system files and folders.
-     * @global array The localization of the core.
      */
     private function renderMessage($deleted)
     {
@@ -117,10 +110,6 @@ class PageDataEditor
      *                       initial request resp. <var>false</var> on failure.
      *
      * @return string HTML
-     *
-     * @global string The script name.
-     * @global array  The localization of the core.
-     * @global array  The CSRF protection object.
      */
     private function render($deleted = null)
     {
@@ -157,8 +146,6 @@ class PageDataEditor
      * Handles requests to the page data editor.
      *
      * @return string HTML
-     *
-     * @global object The CSRF protection object.
      */
     public function process()
     {

--- a/cmsimple/classes/PageDataModel.php
+++ b/cmsimple/classes/PageDataModel.php
@@ -103,9 +103,6 @@ class PageDataModel
      * Fixes the page data after reading.
      *
      * @return void
-     *
-     * @global int   The index of the current page.
-     * @global array The page data of the current page.
      */
     private function fixUp()
     {

--- a/cmsimple/classes/PageDataRouter.php
+++ b/cmsimple/classes/PageDataRouter.php
@@ -374,12 +374,6 @@ class PageDataRouter
      *
      * @param int $s The index of the page.
      *
-     * @global bool
-     * @global string
-     * @global string
-     * @global string
-     * @global object The publisher.
-     *
      * @return string HTML
      */
 // @codingStandardsIgnoreStart

--- a/cmsimple/classes/PageDataView.php
+++ b/cmsimple/classes/PageDataView.php
@@ -93,9 +93,6 @@ class PageDataView
      * @param string $filename Name of the view file.
      *
      * @return string HTML
-     *
-     * @global array          The paths of system files and folders.
-     * @global CSRFProtection The CSRF protector.
      */
     public function view($filename)
     {

--- a/cmsimple/classes/Pages.php
+++ b/cmsimple/classes/Pages.php
@@ -73,11 +73,6 @@ class Pages
 
     /**
      * Constructs an instance.
-     *
-     * @global array The headings of the pages.
-     * @global array The URLs of the pages.
-     * @global array The menu levels of the pages.
-     * @global array The contents of the pages.
      */
     public function __construct()
     {
@@ -210,8 +205,6 @@ class Pages
      * @param bool $ignoreHidden Whether hidden pages should be ignored.
      *
      * @return array of int
-     *
-     * @global array The configuration of the core.
      */
     public function children($n, $ignoreHidden = true)
     {

--- a/cmsimple/classes/PasswordForgotten.php
+++ b/cmsimple/classes/PasswordForgotten.php
@@ -51,12 +51,6 @@ class PasswordForgotten
      * Renders the view.
      *
      * @return void
-     *
-     * @global string The page title.
-     * @global string The generated HTML.
-     * @global string The script name.
-     * @global array  The localization of the core.
-     * @global string JS for the onload attribute of the BODY element.
      */
     private function render()
     {
@@ -89,8 +83,6 @@ class PasswordForgotten
      * @param bool $previous Whether to generate the MAC for the previous hour.
      *
      * @return string
-     *
-     * @global array The configuration of the core.
      */
     public function mac($previous = false)
     {
@@ -121,10 +113,6 @@ class PasswordForgotten
      * with a link to reset the password.
      *
      * @return void
-     *
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
-     * @global string LI elements to be emitted as error messages.
      */
     private function submit()
     {
@@ -157,10 +145,6 @@ class PasswordForgotten
      * info email.
      *
      * @return void.
-     *
-     * @global array  The paths of system files and folders.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
      */
     private function reset()
     {
@@ -193,8 +177,6 @@ class PasswordForgotten
      * @param string $hash A password hash.
      *
      * @return bool
-     *
-     * @global array The paths of system files and folders.
      */
     private function saveNewPassword($hash)
     {

--- a/cmsimple/classes/PluginArrayFileEdit.php
+++ b/cmsimple/classes/PluginArrayFileEdit.php
@@ -36,10 +36,6 @@ abstract class PluginArrayFileEdit extends ArrayFileEdit
 
     /**
      * Constructs an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The current language.
-     * @global string The name of the currently loading plugin.
      */
     public function __construct()
     {

--- a/cmsimple/classes/PluginConfigFileEdit.php
+++ b/cmsimple/classes/PluginConfigFileEdit.php
@@ -29,12 +29,6 @@ class PluginConfigFileEdit extends PluginArrayFileEdit
 {
     /**
      * Constructs an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The name of the currently loading plugin.
-     * @global array  The localization of the core.
-     * @global array  The configuration of the plugins.
-     * @global array  The localization of the plugins.
      */
     public function __construct()
     {

--- a/cmsimple/classes/PluginLanguageFileEdit.php
+++ b/cmsimple/classes/PluginLanguageFileEdit.php
@@ -29,11 +29,6 @@ class PluginLanguageFileEdit extends PluginArrayFileEdit
 {
     /**
      * Constructs an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The name of the currently loading plugin.
-     * @global array  The localization of the core.
-     * @global array  The localization of the plugins.
      */
     public function __construct()
     {

--- a/cmsimple/classes/PluginMenu.php
+++ b/cmsimple/classes/PluginMenu.php
@@ -114,8 +114,6 @@ abstract class PluginMenu
 
     /**
      * Initializes a new instance.
-     *
-     * @global string The script name.
      */
     public function __construct()
     {
@@ -130,9 +128,6 @@ abstract class PluginMenu
      * @param bool $showMain Whether to show the main menu item.
      *
      * @return void
-     *
-     * @global string The name of the current plugin.
-     * @global array  The paths of system files and folders.
      */
     public function render($showMain)
     {
@@ -163,9 +158,6 @@ abstract class PluginMenu
      * Initializes the menu item labels.
      *
      * @return void
-     *
-     * @global array The localization of the core.
-     * @global array The localization of the plugins.
      */
     private function initLabels()
     {
@@ -192,8 +184,6 @@ abstract class PluginMenu
      * Initializes the menu item URLs.
      *
      * @return void
-     *
-     * @global array The paths of system files and folders.
      */
     private function initUrls()
     {

--- a/cmsimple/classes/PluginTextFileEdit.php
+++ b/cmsimple/classes/PluginTextFileEdit.php
@@ -29,10 +29,6 @@ class PluginTextFileEdit extends TextFileEdit
 {
     /**
      * Construct an instance.
-     *
-     * @global array  The paths of system files and folders.
-     * @global string The name of the currently loading plugin.
-     * @global array  The localization of the core.
      */
     public function __construct()
     {

--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -99,9 +99,6 @@ class Search
      * where all words of the search string are contained.
      *
      * @return array
-     *
-     * @global array The content of the pages.
-     * @global array The configuration of the core.
      */
     public function search()
     {
@@ -163,8 +160,6 @@ class Search
      * @param int $count How often the search string was found.
      *
      * @return string HTML
-     *
-     * @global array The localization of the core.
      */
     private function foundMessage($count)
     {
@@ -189,13 +184,6 @@ class Search
      * Returns the search results view.
      *
      * @return string HTML
-     *
-     * @global array  The headings of the pages.
-     * @global array  The URLs of the pages.
-     * @global string The script name.
-     * @global array  The configuration of the core.
-     * @global array  The localization of the core.
-     * @global object The page data router.
      */
     public function render()
     {

--- a/cmsimple/classes/TextFileEdit.php
+++ b/cmsimple/classes/TextFileEdit.php
@@ -59,11 +59,6 @@ abstract class TextFileEdit extends FileEdit
      * Returns the form to edit the file contents.
      *
      * @return string HTML
-     *
-     * @global string The script name.
-     * @global array  The localization of the core.
-     * @global string The title of the current page.
-     * @global object The CSRF protection object.
      */
     public function form()
     {
@@ -101,8 +96,6 @@ abstract class TextFileEdit extends FileEdit
      * Otherwise writes error message to $e, and returns the edit form.
      *
      * @return mixed
-     *
-     * @global object The CSRF protection object.
      */
     public function submit()
     {

--- a/cmsimple/compat.php
+++ b/cmsimple/compat.php
@@ -20,8 +20,6 @@
  *
  * @param string $u Autogallery's installation folder.
  *
- * @global string The URL of the active page.
- *
  * @return string HTML
  *
  * @deprecated since 1.5.4. Use a gallery plugin instead.
@@ -73,8 +71,6 @@ function rp($p)
  *
  * @return string HTML
  *
- * @global array The configuration of the core.
- *
  * @deprecated since 1.5.4. Use `&amp;amp;` instead.
  */
 function amp()
@@ -112,9 +108,6 @@ function guestbooklink()
  * @param string $fl The download URL, e.g. ?download=file.ext
  *
  * @return bool
- *
- * @global array  The paths of system files and folders.
- * @global string The script name.
  *
  * @deprecated since 1.6.
  */
@@ -167,8 +160,6 @@ function rf($fl)
  * @param string $fl       A key of $pth['file'].
  * @param bool   $writable Whether the file has to writable.
  *
- * @global array The paths of system files and folders.
- *
  * @return bool
  *
  * @deprecated since 1.6.
@@ -210,11 +201,6 @@ function chkfile($fl, $writable)
  *
  * @param int $pageIndex The page index.
  *
- * @global bool  Whether edit-mode is active.
- * @global array The contents of all pages.
- * @global int   The Index of the active page.
- * @global array The URLs of all pages.
- *
  * @return void
  *
  * @author mvwd
@@ -247,8 +233,6 @@ function preCallPlugins($pageIndex = -1)
  * @param string $m The log message.
  *
  * @return void
- *
- * @global array  The paths of system files and folders.
  *
  * @deprecated since 1.6
  */

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -125,8 +125,6 @@ function l($n)
  * @param string $__text   The text.
  * @param bool   $__compat Whether only last CMSimple script should be evaluated.
  *
- * @global string The output.
- *
  * @return string
  *
  * @since 1.5
@@ -178,8 +176,6 @@ function evaluate_cmsimple_scripting($__text, $__compat = true)
  * @param string $text The text.
  *
  * @return string
- *
- * @global array The localization of the core.
  *
  * @since 1.5
  */
@@ -312,11 +308,6 @@ function evaluate_scripting($text, $compat = true)
  *
  * @param string $heading The page heading.
  *
- * @global array The content of the pages.
- * @global int   The number of pages.
- * @global array The headings of the pages.
- * @global bool  Whether edit mode is active.
- *
  * @return string HTML
  */
 function newsbox($heading)
@@ -341,9 +332,6 @@ function newsbox($heading)
  *
  * @param array $elementClasses Elements with these classes will become an editor.
  * @param mixed $initFile       The init file or configuration.
- *
- * @global array The paths of system files and folders.
- * @global array The configuration of the core.
  *
  * @return bool
  *
@@ -373,9 +361,6 @@ function init_editor(array $elementClasses = array(), $initFile = false)
 
 /**
  * Calls include_*() of the configured editor. Returns whether that succeeded.
- *
- * @global array The paths of system files and folders.
- * @global array The configuration of the core.
  *
  * @return bool
  *
@@ -411,9 +396,6 @@ function include_editor()
  *
  * @param string $elementID The element with this ID will become an editor.
  * @param string $config    The configuration.
- *
- * @global array The paths of system files and folders.
- * @global array The configuration of the core.
  *
  * @return void
  *
@@ -451,11 +433,6 @@ function editor_replace($elementID = false, $config = '')
  * and $bjs is appended to the body element.
  *
  * @param string $html The HTML generated so far.
- *
- * @global array
- * @global array  The configuration of the core.
- * @global array  The localization of the core.
- * @global string HTML to be preprended to the closing BODY tag.
  *
  * @return string
  *
@@ -615,9 +592,6 @@ function stsl($t)
  *
  * @param string $fl The file name.
  *
- * @global string The script name.
- * @global string The file to download.
- *
  * @return void
  */
 function download($fl)
@@ -647,9 +621,6 @@ function download($fl)
  * @param string $ft A key in $tx['filetype'].
  * @param string $fn The file name.
  *
- * @global string Error messages as HTML fragment consisting of LI Elements.
- * @global array  The localization of the core.
- *
  * @return void
  */
 function e($et, $ft, $fn)
@@ -662,19 +633,6 @@ function e($et, $ft, $fn)
 
 /**
  * Reads and parses the content file and sets global variables accordingly.
- *
- * @global bool   Whether we're in edit mode.
- * @global array  The contents of the pages.
- * @global int    The number of pages.
- * @global array  The headings of the pages.
- * @global array  The URLs of the pages.
- * @global array  The menu levels of the pages.
- * @global string The URL of the current page.
- * @global string The index of the current page.
- * @global array  The localization of the core.
- * @global string Error messages as HTML fragment consisting of LI Elements.
- * @global object The pagedata router.
- * @global object The publisher.
  *
  * @return void
  */
@@ -753,10 +711,6 @@ function rfc()
  *
  * @param string $language The language to read.
  *                         <var>null</var> means the default language.
- *
- * @global array The paths of system files and folders.
- * @global array The configuration of the core.
- * @global bool  Whether edit mode is active.
  *
  * @return array
  *
@@ -878,8 +832,6 @@ function XH_readContents($language = null)
  *
  * @return int
  *
- * @global int   The index of the current page.
- *
  * @since 1.6.3
  */
 function XH_findPreviousPage()
@@ -898,9 +850,6 @@ function XH_findPreviousPage()
  * Finds the index of the next page.
  *
  * @return int
- *
- * @global int The index of the current page.
- * @global int The number of pages.
  *
  * @since 1.6.3
  */
@@ -921,10 +870,6 @@ function XH_findNextPage()
  *
  * @param int    $i The page index.
  * @param string $x Arbitrary appendix of the URL.
- *
- * @global string The script name.
- * @global array  The URLs of the pages.
- * @global array  The configuration of the core.
  *
  * @return string HTML
  */
@@ -948,10 +893,6 @@ function a($i, $x)
  *
  * @param string $n The name attribute.
  *
- * @global array The configuration of the core.
- * @global array The localization of the core.
- * @global bool  Whether print mode is active.
- *
  * @return string HTML
  */
 function meta($n)
@@ -970,10 +911,6 @@ function meta($n)
  * Returns the link to a special CMSimple_XH page, e.g. sitemap.
  *
  * @param string $i A key of $tx['menu'].
- *
- * @global string The requested special function.
- * @global string The script name.
- * @global array  The localization of the core.
  *
  * @return string HTML
  */
@@ -999,8 +936,6 @@ function ml($i)
  * by their according character sequences in $tx['urichar']['new'].
  *
  * @param string $s The URL component.
- *
- * @global array The localization of the core.
  *
  * @return string
  *
@@ -1032,8 +967,6 @@ function uenc($s)
  * @param array  $replace Replacement strings.
  *
  * @return string
- *
- * @global array The configuration of the core.
  *
  * @see uenc()
  *
@@ -1092,9 +1025,6 @@ function cmscript($script, $text)
  *
  * @param int $i The page index.
  *
- * @global array The content of the pages.
- * @global bool  Whether edit mode is active.
- *
  * @return bool
  */
 function hide($i)
@@ -1117,8 +1047,6 @@ function hide($i)
  *
  * @return string HTML
  *
- * @global array The configuration of the core.
- *
  * @deprecated since 1.7
  *
  * @todo Add deprecation warning (XH 1.8?)
@@ -1132,12 +1060,6 @@ function tag($s)
  * Sends error header and sets $title and $o accordingly.
  *
  * @param int $s The HTTP status response code (401, 403, 404).
- *
- * @global bool   Whether the server is IIS.
- * @global bool   Whether the API is CGI.
- * @global array  The localization of the core.
- * @global string The page title.
- * @global string The HTML of the contents area.
  *
  * @return void.
  */
@@ -1180,8 +1102,6 @@ function shead($s)
  * - 4: All errors except notices and warnings
  * - 5: All errors except notices
  * - 6: All errors
- *
- * @global array The paths of system files and folders.
  *
  * @return boolean Whether error_reporting is enabled.
  *
@@ -1244,8 +1164,6 @@ function XH_debugmode()
  * @param string $errstr  An error message.
  * @param string $errfile Filename where error was raised.
  * @param int    $errline Line number where error was raised.
- *
- * @global array The list of PHP errors formatted as HTML fragment.
  *
  * @return void
  */
@@ -1314,8 +1232,6 @@ function XH_debug($errno, $errstr, $errfile, $errline)
  *
  * @return void
  *
- * @global array The localization of the core.
- *
  * @since 1.5.5
  */
 function XH_checkValidUtf8(array $arr)
@@ -1370,12 +1286,7 @@ function XH_createLanguageFile($dst)
  *
  * @param string $plugin The name of the plugin.
  *
- * @global array  The paths of system files and folders.
- * @global string The active language.
- *
  * @return void
- *
- * @staticvar array The help filename cache.
  */
 function pluginFiles($plugin)
 {
@@ -1430,12 +1341,6 @@ function pluginFiles($plugin)
  * @param bool $admin Whether to return only plugins with a admin.php
  *
  * @return array
- *
- * @global array The paths of system files and folders.
- * @global array The configuration of the core.
- *
- * @staticvar array The plugin name cache.
- * @staticvar array The admin plugin name cache.
  *
  * @since 1.6
  *
@@ -1494,8 +1399,6 @@ function gc($s)
 /**
  * Returns wether the user is logged in.
  *
- * @global array The configuration of the core.
- *
  * @return bool.
  */
 function logincheck()
@@ -1518,8 +1421,6 @@ function logincheck()
  * @param string $description A description.
  *
  * @return bool
- *
- * @global array The paths of system files and folders.
  *
  * @since 1.6
  */
@@ -1544,15 +1445,6 @@ function XH_logMessage($type, $module, $category, $description)
 
 /**
  * Returns the login form.
- *
- * @global array  The configuration of the core.
- * @global array  The localization of the core.
- * @global string JavaScript for the onload event of the BODY element.
- * @global string The requested special function.
- * @global string The HTML of the contents area.
- * @global int    The index of the requested page.
- * @global string The script name.
- * @global string The URL of the selected page.
  *
  * @return string HTML
  */
@@ -1654,8 +1546,6 @@ function XH_writeFile($filename, $contents)
  *
  * @return void
  *
- * @staticvar array The callbacks for later execution.
- *
  * @since 1.6
  */
 function XH_afterPluginLoading($callback = null)
@@ -1706,8 +1596,6 @@ function XH_afterFinalCleanUp($param)
  * If necessary, this stylesheet will be created/updated.
  *
  * @return string
- *
- * @global array  The paths of system files and folders.
  *
  * @since 1.6
  */
@@ -1826,8 +1714,6 @@ function XH_message($type, $message)
  *
  * @return string HTML
  *
- * @global array The paths of system files and folders.
- *
  * @since 1.6
  */
 function XH_backup()
@@ -1849,8 +1735,6 @@ function XH_backup()
  * @param string $name The name to check.
  *
  * @return bool
- *
- * @global array The paths of system files and folders.
  *
  * @since 1.6
  */
@@ -1896,8 +1780,6 @@ function XH_title($site, $subtitle)
  * @return string HTML
  *
  * @since 1.6
- *
- * @global XH_CSRFProtection The CSRF protector.
  */
 function XH_builtinTemplate($bodyClass)
 {
@@ -1921,9 +1803,6 @@ function XH_builtinTemplate($bodyClass)
  * @param string $tooltip A tooltip in HTML.
  *
  * @return string HTML
- *
- * @global array The paths of system files and folders.
- * @global array The localization of the core.
  *
  * @since 1.6
  *
@@ -1964,8 +1843,6 @@ function XH_isContentBackup($filename, $regularOnly = true)
  *
  * @return array
  *
- * @global array The paths of system files and folders.
- *
  * @since 1.6
  */
 function XH_templates()
@@ -1993,8 +1870,6 @@ function XH_templates()
  *
  * @return array
  *
- * @global array The paths of system files and folders.
- *
  * @since 1.6
  */
 function XH_availableLocalizations()
@@ -2018,10 +1893,6 @@ function XH_availableLocalizations()
  * Returns the installed second languages in alphabetic order.
  *
  * @return array
- *
- * @global array The paths of system files and folders.
- *
- * @staticvar array The language names cache.
  *
  * @since 1.6
  */
@@ -2150,8 +2021,6 @@ function XH_convertPrintUrls($pageContent)
  *
  * @return mixed
  *
- * @global object The JSON codec.
- *
  * @since 1.6
  *
  * @todo Deprecate starting with 1.8.
@@ -2169,8 +2038,6 @@ function XH_decodeJson($string)
  * @return string or
  *         bool false on JSON error
  *
- * @global object The JSON codec.
- *
  * @since 1.6
  *
  * @todo Deprecate starting with 1.8.
@@ -2185,8 +2052,6 @@ function XH_encodeJson($value)
  * during the last {@link XH_decodeJSON()}.
  *
  * @return bool
- *
- * @global object The JSON codec.
  *
  * @since 1.6
  *
@@ -2227,8 +2092,6 @@ function XH_hsc($string)
  *                        instead of the subject default in localization.
  *
  * @return string HTML
- *
- * @global array The configuration of the core.
  *
  * @since 1.6
  */
@@ -2304,8 +2167,6 @@ function XH_numberSuffix($count)
  * @param bool $language Whether to return the language array (opposed to config).
  *
  * @return array
- *
- * @global array The paths of system files and folders.
  *
  * @since 1.6
  */
@@ -2416,9 +2277,6 @@ function XH_exit($status = 0)
  *
  * @return string
  *
- * @global string The script name.
- * @global string The current language.
- *
  * @since 1.6.2
  */
 function XH_getRootFolder()
@@ -2441,8 +2299,6 @@ function XH_getRootFolder()
  * @param string $plugin A plugin name or <var>null</var>.
  *
  * @return mixed
- *
- * @staticvar array The registered plugins.
  *
  * @since 1.6.2
  */
@@ -2521,8 +2377,6 @@ function XH_registeredEditmenuPlugins()
  *
  * @return void
  *
- * @global array The localization of the core.
- *
  * @since 1.6.3
  */
 function XH_onShutdown()
@@ -2546,9 +2400,6 @@ function XH_onShutdown()
  * @param int $timestamp A UNIX timestamp.
  *
  * @return string
- *
- * @global array The configuration of the core.
- * @global array The localization of the core.
  *
  * @since 1.6.3
  */
@@ -2617,8 +2468,6 @@ function XH_highlightSearchWords(array $words, $text)
  *
  * @return void
  *
- * @global array The paths of system files and folders.
- *
  * @since 1.7
  */
 function XH_autoload($className)
@@ -2686,10 +2535,6 @@ function XH_startSession()
  *
  * @return The HTML.
  *
- * @global array The configuration of the core.
- * @global array The language localization of the core.
- * @global array The paths of system files and folders.
- *
  * @since 1.7
  */
 function XH_poweredBy()
@@ -2744,8 +2589,6 @@ function XH_poweredBy()
  *
  * @return string The URL
  *
- * @global array The paths of system files and folders.
- *
  * @since 1.7
  */
 function XH_pluginURL($plugin)
@@ -2779,15 +2622,6 @@ function XH_pluginURL($plugin)
  * element is null.
  *
  * @return array
- *
- * @global string The title of the page.
- * @global array  The headings of the pages.
- * @global int    The index of the current page.
- * @global string The requested special function.
- * @global array  The menu levels of the pages.
- * @global array  The localization of the core.
- * @global array  The configuration of the core.
- * @global object The publisher.
  *
  * @since 1.7
  */
@@ -2846,9 +2680,6 @@ function XH_getLocatorModel()
  *
  * @return string
  *
- * @global string The script name.
- * @global array  The page URLs.
- *
  * @since 1.7
  */
 function XH_getPageURL($index)
@@ -2862,8 +2693,6 @@ function XH_getPageURL($index)
  * Returns the URL where to redirect `selected` GEt requests.
  *
  * @return string
- *
- * @global string The value of the `selected` GP parameter.
  *
  * @since 1.7.0
  */

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -20,9 +20,6 @@
  *
  * @return string HTML
  *
- * @global string The script name.
- * @global array  The page URLs.
- *
  * @since 1.6.3
  */
 function XH_renderPrevLink()
@@ -42,9 +39,6 @@ function XH_renderPrevLink()
  *
  * @return string HTML
  *
- * @global string The script name.
- * @global array  The page URLs.
- *
  * @since 1.6.3
  */
 function XH_renderNextLink()
@@ -63,12 +57,6 @@ function XH_renderNextLink()
  * Returns the complete HEAD element.
  *
  * @return string HTML
- *
- * @global string The page title.
- * @global array  The configuration of the core.
- * @global array  The paths of system files and folders.
- * @global array  The localization of the core.
- * @global string HTML to be inserted to the HEAD Element.
  */
 function head()
 {
@@ -102,8 +90,6 @@ function head()
  * Returns the language dependend site title.
  *
  * @return string HTML
- *
- * @global array The localization of the core.
  */
 function sitename()
 {
@@ -117,8 +103,6 @@ function sitename()
  * Returns the global site title.
  *
  * @return string HTML
- *
- * @global array The configuration of the core.
  */
 function pagename()
 {
@@ -132,8 +116,6 @@ function pagename()
  * Returns the onload attribute for the body element.
  *
  * @return string HTML
- *
- * @global string JavaScript for the onload attribute of the BODY element.
  */
 function onload()
 {
@@ -151,11 +133,6 @@ function onload()
  * @param callable $li    A callback that actually creates the view.
  *
  * @return string HTML
- *
- * @global int   The number of pages.
- * @global int   The index of the current page.
- * @global array The menu levels of the pages.
- * @global array The configuration of the core.
  */
 function toc($start = null, $end = null, $li = 'li')
 {
@@ -231,13 +208,6 @@ function li(array $ta, $st)
  *
  * @return void
  *
- * @global int   The number of pages.
- * @global int   The current page index.
- * @global array The configuration of the core.
- * @global int   The index of the current page in {@link $hc}.
- * @global array The page indexes of the visible menu items.
- * @global int   The length of {@link $hc}.
- *
  * @since 1.6.2
  */
 function XH_buildHc()
@@ -265,9 +235,6 @@ function XH_buildHc()
  * Returns the search form.
  *
  * @return string HTML
- *
- * @global string The script name.
- * @global array  The localization of the core.
  */
 function searchbox()
 {
@@ -299,8 +266,6 @@ function sitemaplink()
  * Returns the link for the print view.
  *
  * @return string HTML
- *
- * @global array  The localization of the core.
  */
 function printlink()
 {
@@ -314,11 +279,6 @@ function printlink()
  * Returns the URL of the print view.
  *
  * @return string
- *
- * @global string The requested special function.
- * @global string The current search string.
- * @global string The requested special file.
- * @global string The script name.
  *
  * @since 1.6
  */
@@ -344,8 +304,6 @@ function XH_printUrl()
  * Returns the link to the mail form.
  *
  * @return string HTML
- *
- * @global array The configuration of the core.
  */
 function mailformlink()
 {
@@ -358,9 +316,6 @@ function mailformlink()
 
 /**
  * Returns the link to the login form.
- *
- * @global int    The index of the requested page.
- * @global array  The localization of the core.
  *
  * @return string HTML
  */
@@ -382,9 +337,6 @@ function loginlink()
  * @param int  $hour The time correction in hours.
  *
  * @return string HTML
- *
- * @global array The localization of the core.
- * @global array The paths of system files and folders.
  */
 function lastupdate($br = null, $hour = null)
 {
@@ -455,11 +407,6 @@ function editmenu()
  * Returns the contents area.
  *
  * @return string HTML
- *
- * @global int    The index of the current page.
- * @global string The output of the contents area.
- * @global array  The content of the pages.
- * @global bool   Whether edit mode is active.
  */
 function content()
 {
@@ -483,12 +430,6 @@ function content()
  * @param string $html Optional markup to wrap the heading.
  *
  * @return string HTML
- *
- * @global int   The index of the current page.
- * @global int   The number of pages.
- * @global array The menu levels of the pages.
- * @global array The localization of the core.
- * @global array The configuration of the core.
  */
 function submenu($html = '')
 {
@@ -529,8 +470,6 @@ function submenu($html = '')
  *
  * @return string HTML
  *
- * @global array The localization of the core.
- *
  * @see nextpage()
  */
 function previouspage()
@@ -547,8 +486,6 @@ function previouspage()
  * Returns a link to the next page
  *
  * @return string HTML
- *
- * @global array The localization of the core.
  *
  * @see previouspage()
  */
@@ -568,10 +505,6 @@ function nextpage()
  * To work, an appropriate ID has to be defined in the template.
  *
  * @param string $id An (X)HTML ID.
- *
- * @return string HTML
- *
- * @global array The localization of the core.
  */
 function top($id = 'TOP')
 {
@@ -585,10 +518,6 @@ function top($id = 'TOP')
  * Returns the language menu.
  *
  * @return string HTML
- *
- * @global array  The paths of system files and folders.
- * @global array  The configuration of the core.
- * @global string The current language.
  */
 function languagemenu()
 {
@@ -659,8 +588,6 @@ function XH_emergencyTemplate()
  * @param string $linktext The text to be displayed as the link in the template.
  *
  * @return string The link.
- *
- * @global string The site (script) name.
  *
  * @since 1.7
  */

--- a/plugins/filebrowser/admin.php
+++ b/plugins/filebrowser/admin.php
@@ -117,10 +117,6 @@ if (isset($_GET['filebrowser']) && $_GET['filebrowser'] == 'editorbrowser') {
  * Handles the editorbrowser.
  *
  * @return void
- *
- * @global array                  The paths of system files and folders.
- * @global XH\CSRFProtection      The CSRF protector.
- * @global Filebrowser_Controller The filebrowser controller.
  */
 function Filebrowser_forEditor()
 {

--- a/plugins/filebrowser/classes/Controller.php
+++ b/plugins/filebrowser/classes/Controller.php
@@ -128,9 +128,6 @@ class Controller
 
     /**
      * Constructs an instance.
-     *
-     * @global array The paths of system files and folders.
-     * @global array The configuration of the plugins.
      */
     public function __construct()
     {
@@ -181,10 +178,6 @@ class Controller
      *
      * @param string $file A file name.
      *
-     * @global array The headings of the pages.
-     * @global array The content of the pages.
-     * @global array The URLs of the pages.
-     *
      * @return array
      */
     private function fileIsLinked($file)
@@ -215,10 +208,6 @@ class Controller
      * where the images are used.
      *
      * @return array
-     *
-     * @global array The content of the pages.
-     * @global array The headings of the pages.
-     * @global int   The number of pages.
      */
     public function usedImages()
     {

--- a/plugins/filebrowser/classes/View.php
+++ b/plugins/filebrowser/classes/View.php
@@ -122,8 +122,6 @@ class View
 
     /**
      * Initializes a newly created instance.
-     *
-     * @global array  The localization of the plugins.
      */
     public function __construct()
     {
@@ -138,8 +136,6 @@ class View
      * @param array $folders An array of folders.
      *
      * @return string HTML
-     *
-     * @global array The localization of the core.
      */
     private function folderList(array $folders)
     {
@@ -204,9 +200,6 @@ class View
      * @param array $folders An array of folders.
      *
      * @return string
-     *
-     * @global object The CRSF protection object.
-     * @global string The script name.
      */
     private function subfolderList(array $folders)
     {
@@ -243,10 +236,6 @@ class View
      * @param array $files An array of files.
      *
      * @return string
-     *
-     * @global string     The script name.
-     * @global object     The CRSF protection object.
-     * @global Controller The filebrowser controller.
      */
     private function fileList(array $files)
     {
@@ -499,8 +488,6 @@ class View
      * Renders the JavaScript configuration script element.
      *
      * @return string HTML
-     *
-     * @global array The localization of the plugins.
      *
      * @SuppressWarnings(PHPMD.UnusedPrivateMethod)
      */

--- a/plugins/meta_tags/Metatags_view.php
+++ b/plugins/meta_tags/Metatags_view.php
@@ -23,12 +23,6 @@
  *                    that will destroy input-fields.
  *
  * @return string
- *
- * @global string The site name.
- * @global array  The paths of system files and folders.
- * @global string The URL of the requested page.
- * @global array  The localization of the plugins.
- * @global string The HTML fragment to insert at the bottom of the body element.
  */
 function Metatags_view(array $page)
 {

--- a/plugins/page_params/Pageparams_view.php
+++ b/plugins/page_params/Pageparams_view.php
@@ -21,9 +21,6 @@
  * @return string HTML
  *
  * @since 1.6
- *
- * @global array The paths of system files and folders.
- * @global array The localization of the plugins.
  */
 function Pageparams_hjs()
 {
@@ -80,8 +77,6 @@ function Pageparams_checkbox($name, $checked)
  *
  * @return string HTML
  *
- * @global array The localization of the plugins.
- *
  * @since 1.6
  */
 function Pageparams_lastEditRadiogroup($value)
@@ -106,8 +101,6 @@ function Pageparams_lastEditRadiogroup($value)
  * @param int $value The current value.
  *
  * @return string HTML
- *
- * @global array The localization of the plugins.
  *
  * @since 1.6
  */
@@ -172,8 +165,6 @@ function Pageparams_scheduleInput($name, $value, $disabled)
  *
  * @return string HTML
  *
- * @global array The localization of the plugins.
- *
  * @since 1.6
  */
 function Pageparams_templateSelectbox(array $page)
@@ -208,8 +199,6 @@ function Pageparams_templateSelectbox(array $page)
  *
  * @return string HTML
  *
- * @global array The localization of the plugins.
- *
  * @since 1.6
  */
 function Pageparams_linkList($default, $disabled)
@@ -237,11 +226,6 @@ function Pageparams_linkList($default, $disabled)
  * @param array $page Page data of the current page.
  *
  * @return string HTML
- *
- * @global string The script name.
- * @global string The URL of the current page.
- * @global string Document fragment to insert into the HEAD element.
- * @global array  The localization of the plugins.
  */
 function Pageparams_view(array $page)
 {

--- a/plugins/page_params/index.php
+++ b/plugins/page_params/index.php
@@ -35,8 +35,6 @@ if (!defined('PLUGINLOADER_VERSION')) {
  *
  * @return void
  *
- * @global array  The content of the pages.
- *
  * @since 1.6
  */
 function Pageparams_handleRelocation($index, array $data)
@@ -60,10 +58,6 @@ function Pageparams_handleRelocation($index, array $data)
  * @param int $n Index of the current page.
  *
  * @return void
- *
- * @global array  The paths of system files and folders.
- * @global array  The configuration of the core.
- * @global object The page data router.
  *
  * @since 1.6
  */

--- a/tests/unit/ControllerBackendFTest.php
+++ b/tests/unit/ControllerBackendFTest.php
@@ -50,9 +50,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'validate'.
      *
      * @return void
-     *
-     * @global string Whether the link check is requested.
-     * @global string The requested function.
      */
     public function testValidate()
     {
@@ -67,9 +64,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'do_validate'.
      *
      * @return void
-     *
-     * @global string Whether the actual link check is requested.
-     * @global string The requested function.
      */
     public function testDoValidate()
     {
@@ -84,9 +78,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'settings'.
      *
      * @return void
-     *
-     * @global string Whether the settings page is requested.
-     * @global string The requested function.
      */
     public function testSettings()
     {
@@ -101,9 +92,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'xh_backups'.
      *
      * @return void
-     *
-     * @global string Whether the backup page is requested.
-     * @global string The requested function.
      */
     public function testBackups()
     {
@@ -118,9 +106,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'xh_pagedata'.
      *
      * @return void
-     *
-     * @global string Whether the pagedata editor is requested.
-     * @global string The requested function.
      */
     public function testPagedata()
     {
@@ -135,9 +120,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'sysinfo'.
      *
      * @return void
-     *
-     * @global string Whether the system info is requested.
-     * @global string The requested function.
      */
     public function testSysinfo()
     {
@@ -152,9 +134,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'phpinfo'.
      *
      * @return void
-     *
-     * @global string Whether the PHP info is requested.
-     * @global string The requested function.
      */
     public function testPhpinfo()
     {
@@ -169,9 +148,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'file'.
      *
      * @return void
-     *
-     * @global string The name of a special file to be handled.
-     * @global string The requested function.
      */
     public function testFile()
     {
@@ -186,10 +162,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'userfiles'.
      *
      * @return void
-     *
-     * @global string Whether the file browser is requested to show the
-     *                userfiles folder.
-     * @global string The requested function.
      */
     public function testUserfiles()
     {
@@ -204,10 +176,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'images'.
      *
      * @return void
-     *
-     * @global string Whether the file browser is requested to show the image
-     *                folder.
-     * @global string The requested function.
      */
     public function testImages()
     {
@@ -222,10 +190,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'downloads'.
      *
      * @return void
-     *
-     * @global string Whether the file browser is requested to show the download
-     *                folder.
-     * @global string The requested function.
      */
     public function testDownloads()
     {
@@ -240,9 +204,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'save'.
      *
      * @return void
-     *
-     * @global string The requested function.
-     * @global string The requested function.
      */
     public function testSave()
     {
@@ -257,10 +218,6 @@ class ControllerBackendFTest extends TestCase
      * Tests $f == 'save' when system info and saving are requested.
      *
      * @return void
-     *
-     * @global string The requested function.
-     * @global string Whether the system info is requested.
-     * @global string The requested function.
      */
     public function testSysinfoAndSave()
     {

--- a/tests/unit/ControllerFileBackupTest.php
+++ b/tests/unit/ControllerFileBackupTest.php
@@ -40,9 +40,6 @@ class ControllerFileBackupTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global string            The name of a special file to be handled.
-     * @global CSRFProtection The CRSF protector.
      */
     protected function setUp()
     {
@@ -64,8 +61,6 @@ class ControllerFileBackupTest extends TestCase
      * Tests that the CSRF token is checked.
      *
      * @return void
-     *
-     * @global CSRFProtection The CRSF protector.
      */
     public function testChecksCsrfToken()
     {

--- a/tests/unit/ControllerFileEditTest.php
+++ b/tests/unit/ControllerFileEditTest.php
@@ -60,9 +60,6 @@ class ControllerFileEditTest extends TestCase
      * Tests that the array action calls FileEdit::form().
      *
      * @return void
-     *
-     * @global string The name of a special file to be handled.
-     * @global string The requested action.
      */
     public function testArrayActionCallsForm()
     {
@@ -78,9 +75,6 @@ class ControllerFileEditTest extends TestCase
      * Tests that the save action calls FileEdit::submit().
      *
      * @return void
-     *
-     * @global string The name of a special file to be handled.
-     * @global string The requested action.
      */
     public function testSaveActionCallsSubmit()
     {

--- a/tests/unit/ControllerFileViewTest.php
+++ b/tests/unit/ControllerFileViewTest.php
@@ -61,8 +61,6 @@ class ControllerFileViewTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global string The name of a special file to be handled.
      */
     protected function setUp()
     {
@@ -80,8 +78,6 @@ class ControllerFileViewTest extends TestCase
      * Sets up the file system.
      *
      * @return void
-     *
-     * @global array The paths of system files and folders.
      */
     protected function setUpFileSystem()
     {
@@ -150,8 +146,6 @@ class ControllerFileViewTest extends TestCase
      * Tests the log file view.
      *
      * @return void
-     *
-     * @global string The name of a special file to be handled.
      */
     public function testLogFile()
     {

--- a/tests/unit/ControllerFrontendFTest.php
+++ b/tests/unit/ControllerFrontendFTest.php
@@ -50,9 +50,6 @@ class ControllerFrontendFTest extends TestCase
      * Tests $f == 'forgotten'.
      *
      * @return void
-     *
-     * @global string The requested function.
-     * @global string The requested function.
      */
     public function testForgotten()
     {
@@ -67,9 +64,6 @@ class ControllerFrontendFTest extends TestCase
      * Tests $f == 'search'.
      *
      * @return void
-     *
-     * @global string The requested function.
-     * @global string The requested function.
      */
     public function testSearch()
     {
@@ -84,10 +78,6 @@ class ControllerFrontendFTest extends TestCase
      * Tests $f == 'mailform' for mailform display.
      *
      * @return void
-     *
-     * @global string The URL of the current page.
-     * @global string Whether the mailform is requested.
-     * @global string The requested function.
      */
     public function testMailformDisplay()
     {
@@ -103,10 +93,6 @@ class ControllerFrontendFTest extends TestCase
      * Test $f == 'mailform' for mailform submission.
      *
      * @return void
-     *
-     * @global string The URL of the current page.
-     * @global string The requested function.
-     * @global string The requested function.
      */
     public function testMailformSubmission()
     {
@@ -122,10 +108,6 @@ class ControllerFrontendFTest extends TestCase
      * Tests $f == 'sitemap'.
      *
      * @return void
-     *
-     * @global string The URL of the current page.
-     * @global string Whether the sitemap is requested.
-     * @global string The requested function.
      */
     public function testSitemap()
     {
@@ -141,10 +123,6 @@ class ControllerFrontendFTest extends TestCase
      * Tests $f == 'xhpages'.
      *
      * @return void
-     *
-     * @global string The URL of the current page.
-     * @global string Whether the page manager is requested.
-     * @global string The requested function.
      */
     public function testXhpages()
     {
@@ -159,11 +137,6 @@ class ControllerFrontendFTest extends TestCase
      * Tests $f == 'sitemap', if search and sitemap are requested.
      *
      * @return void
-     *
-     * @global string The URL of the current page.
-     * @global string Whether the sitemap is requested.
-     * @global string The requested function.
-     * @global string The requested function.
      */
     public function testSearchAndSitemap()
     {

--- a/tests/unit/ControllerLoginTest.php
+++ b/tests/unit/ControllerLoginTest.php
@@ -54,8 +54,6 @@ class ControllerLoginTest extends ControllerLogInOutTestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global array        The configuration of the core.
      */
     protected function setUp()
     {
@@ -98,8 +96,6 @@ class ControllerLoginTest extends ControllerLogInOutTestCase
      * Tests that login success set the session variables.
      *
      * @return void
-     *
-     * @global array        The configuration of the core.
      */
     public function testSuccessSetsSessionVariables()
     {
@@ -143,9 +139,6 @@ class ControllerLoginTest extends ControllerLogInOutTestCase
      * Tests that login failure sets global variables.
      *
      * @return void
-     *
-     * @global string       The requested function.
-     * @global string       Whether login is requested.
      */
     public function testFailSetsGlobalVariables()
     {

--- a/tests/unit/ControllerLogoutTest.php
+++ b/tests/unit/ControllerLogoutTest.php
@@ -42,9 +42,6 @@ class ControllerLogoutTest extends ControllerLogInOutTestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global PasswordHash The password hasher.
-     * @global array        The configuration of the core.
      */
     protected function setUp()
     {
@@ -109,8 +106,6 @@ class ControllerLogoutTest extends ControllerLogInOutTestCase
      * Tests that logout sets $f.
      *
      * @return void
-     *
-     * @global string The requested function.
      */
     public function testSetsF()
     {

--- a/tests/unit/ControllerMailformTest.php
+++ b/tests/unit/ControllerMailformTest.php
@@ -54,9 +54,6 @@ class ControllerMailformTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global array The configuration of the core.
-     * @global array The localization of the core.
      */
     protected function setUp()
     {
@@ -80,8 +77,6 @@ class ControllerMailformTest extends TestCase
      * Tests that the title is set.
      *
      * @return void
-     *
-     * @global string The content of the title element.
      */
     public function testSetsTitle()
     {
@@ -95,8 +90,6 @@ class ControllerMailformTest extends TestCase
      * Tests the rendered HTML.
      *
      * @return void
-     *
-     * @global string The HTML of the content area.
      */
     public function testRenderedHTML()
     {
@@ -121,8 +114,6 @@ class ControllerMailformTest extends TestCase
      * Tests that shead() is called when the mailform is disabled.
      *
      * @return void
-     *
-     * @global array The configuration of the core.
      */
     public function testCallsSheadWhenMailformIsDisabled()
     {

--- a/tests/unit/ControllerSavePageDataTest.php
+++ b/tests/unit/ControllerSavePageDataTest.php
@@ -68,10 +68,6 @@ class ControllerSavePageDataTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global int            The index of the currently selected page.
-     * @global PageDataRouter The page data router.
-     * @global CSRFProtection The CSRF protector.
      */
     protected function setUp()
     {
@@ -104,9 +100,6 @@ class ControllerSavePageDataTest extends TestCase
      * Tests that PageDataRouter::update() is called.
      *
      * @return void
-     *
-     * @global int            The index of the currently selected page.
-     * @global PageDataRouter The page data router.
      */
     public function testCallsUpdate()
     {
@@ -121,8 +114,6 @@ class ControllerSavePageDataTest extends TestCase
      * Tests that Ajax success outputs a message.
      *
      * @return void
-     *
-     * @global PageDataRouter The page data router.
      */
     public function testAjaxSuccessOutputsMessage()
     {
@@ -139,8 +130,6 @@ class ControllerSavePageDataTest extends TestCase
      * Tests that Ajax failure outputs a message.
      *
      * @return void
-     *
-     * @global PageDataRouter The page data router.
      */
     public function testAjaxFailureOutputsMessage()
     {
@@ -169,8 +158,6 @@ class ControllerSavePageDataTest extends TestCase
      * Tests that no Ajax success does not call e().
      *
      * @return void
-     *
-     * @global PageDataRouter The page data router.
      */
     public function testNoAjaxSuccessDoesNotCallE()
     {
@@ -186,8 +173,6 @@ class ControllerSavePageDataTest extends TestCase
      * Tests that no Ajax failure calls e().
      *
      * @return void
-     *
-     * @global PageDataRouter The page data router.
      */
     public function testNoAjaxFailureCallsE()
     {

--- a/tests/unit/ControllerSearchTest.php
+++ b/tests/unit/ControllerSearchTest.php
@@ -47,8 +47,6 @@ class ControllerSearchTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global array The localization of the core.
      */
     protected function setUp()
     {
@@ -65,8 +63,6 @@ class ControllerSearchTest extends TestCase
      * Tests that the title is set.
      *
      * @return void
-     *
-     * @global string The content of the title element.
      */
     public function testSetsTitle()
     {

--- a/tests/unit/ControllerSitemapTest.php
+++ b/tests/unit/ControllerSitemapTest.php
@@ -54,9 +54,6 @@ class ControllerSitemapTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global int   The number of pages.
-     * @global array The localization of the core.
      */
     protected function setUp()
     {
@@ -81,8 +78,6 @@ class ControllerSitemapTest extends TestCase
      * Tests that the title is set.
      *
      * @return void
-     *
-     * @global string The content of the title element.
      */
     public function testSetsTitle()
     {
@@ -96,8 +91,6 @@ class ControllerSitemapTest extends TestCase
      * Tests the rendered HTML.
      *
      * @return void
-     *
-     * @global string The HTML of the contents area.
      */
     public function testRenderedHTML()
     {

--- a/tests/unit/ControllerStandardHeaderTest.php
+++ b/tests/unit/ControllerStandardHeaderTest.php
@@ -61,8 +61,6 @@ class ControllerStandardHeaderTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global array The configuration of the core.
      */
     protected function setUp()
     {

--- a/tests/unit/FinalCleanUpTest.php
+++ b/tests/unit/FinalCleanUpTest.php
@@ -59,10 +59,6 @@ class FinalCleanUpTest extends TestCase
      * Sets up the global variables of the test fixture.
      *
      * @return void
-     *
-     * @global array  PHP errors, warnings and notices.
-     * @global array  The configuration of the core.
-     * @global string The script elements to insert at the bottom of the body.
      */
     private function setUpGlobals()
     {
@@ -163,8 +159,6 @@ class FinalCleanUpTest extends TestCase
      * Tests the scrolling admin menu.
      *
      * @return void
-     *
-     * @global array The configuration of the core.
      */
     public function testScrollingAdminMenu()
     {

--- a/tests/unit/HeadTest.php
+++ b/tests/unit/HeadTest.php
@@ -50,10 +50,6 @@ class HeadTest extends TestCase
      * Sets up the test fixture.
      *
      * @return void
-     *
-     * @global array The paths of system files and folders.
-     * @global array The configuration of the core.
-     * @global array The localization of the core.
      */
     protected function setUp()
     {
@@ -164,9 +160,6 @@ class HeadTest extends TestCase
      * Tests that the prev link is rendered.
      *
      * @return void
-     *
-     * @global string The script name.
-     * @global array  The page URLs.
      */
     public function testRendersPrevLink()
     {
@@ -187,9 +180,6 @@ class HeadTest extends TestCase
      * Tests that the next page link is rendered.
      *
      * @return void
-     *
-     * @global string The script name.
-     * @global array  The page URLs.
      */
     public function testRendersNextLink()
     {

--- a/tests/unit/MenuTest.php
+++ b/tests/unit/MenuTest.php
@@ -32,8 +32,6 @@ class MenuTest extends TestCase
      * Sets up the default fixture.
      *
      * @return void
-     *
-     * @global int The index of the selected page.
      */
     protected function setUp()
     {
@@ -52,11 +50,6 @@ class MenuTest extends TestCase
      * Sets up the default page structure.
      *
      * @return void
-     *
-     * @global int   The number of pages.
-     * @global array The headings of the pages.
-     * @global array The URLs of the pages.
-     * @global array The levels of the pages.
      */
     private function setUpPageStructure()
     {
@@ -96,8 +89,6 @@ class MenuTest extends TestCase
      * Sets up the default configuration options.
      *
      * @return void
-     *
-     * @global array The configuration of the core.
      */
     private function setUpConfiguration()
     {
@@ -124,8 +115,6 @@ class MenuTest extends TestCase
      * @param bool $flag Whether to enable edit mode.
      *
      * @return void
-     *
-     * @global bool Whether edit mode is enabled.
      */
     private function setUpEditMode($flag)
     {
@@ -139,8 +128,6 @@ class MenuTest extends TestCase
      * Sets up the default page data router mock.
      *
      * @return void
-     *
-     * @global PageDataRouter The page data router.
      */
     private function setUpPageDataRouterMock()
     {
@@ -213,8 +200,6 @@ class MenuTest extends TestCase
      *
      * @return void
      *
-     * @global int The index of the selected page.
-     *
      * @dataProvider dataForToc
      */
     public function testToc($start, $end, array $expected)
@@ -250,11 +235,6 @@ class MenuTest extends TestCase
      * Tests that two menu levels have the expected result.
      *
      * @return void
-     *
-     * @global array The levels of the pages.
-     * @global int   The number of pages.
-     * @global int   The index of the selected page.
-     * @global array The configuration of the core.
      */
     public function testTwoMenuLevelsToc()
     {
@@ -271,9 +251,6 @@ class MenuTest extends TestCase
      * Tests that show_hidden->pages_toc has the expected result.
      *
      * @return void
-     *
-     * @global int   The index of the selected page.
-     * @global array The configuration of the core.
      */
     public function testTocShowHiddenPagesShowsHiddenPage()
     {
@@ -288,9 +265,6 @@ class MenuTest extends TestCase
      * Tests that menu_levelcatch doesn't have a far subpage.
      *
      * @return void
-     *
-     * @global int   The index of the selected page.
-     * @global array The configuration of the core.
      */
     public function testLevelcatchDoesntFarSubpage()
     {
@@ -305,8 +279,6 @@ class MenuTest extends TestCase
      * Tests that no selected page has only toplevel pages.
      *
      * @return void
-     *
-     * @global int The index of the selected page.
      */
     public function testNoPageSelectedHasToplevelsOnly()
     {
@@ -472,8 +444,6 @@ class MenuTest extends TestCase
      * Tests that a selected page with children has the class "docs".
      *
      * @return void
-     *
-     * @global int The index of the selected page.
      */
     public function testSelectedPageHasClassSdocs()
     {
@@ -519,8 +489,6 @@ class MenuTest extends TestCase
      * Tests that a not selected childless page has the class "doc".
      *
      * @return void
-     *
-     * @global int The index of the selected page.
      */
     public function testNotSelectedChildlessPageHasClassDoc()
     {
@@ -542,9 +510,6 @@ class MenuTest extends TestCase
      * @param string $class A CSS class.
      *
      * @return void
-     *
-     * @global int   The index of the selected page.
-     * @global array The configuration of the core.
      *
      * @dataProvider dataForParentOfSelectedPageHasClassDependingOnSdoc
      */
@@ -582,8 +547,6 @@ class MenuTest extends TestCase
      * @param string $class      A CSS class.
      *
      * @return void
-     *
-     * @global array The configuration of the core.
      *
      * @dataProvider dataForH1WithH3HasClassDependingOnLevelcatch
      */
@@ -657,8 +620,6 @@ class MenuTest extends TestCase
      * Tests that the "Blog" submenu has exactly three items.
      *
      * @return void
-     *
-     * @global int The index of the selected page.
      */
     public function testBlogSubmenuHasExactlyThreeItems()
     {

--- a/tests/unit/TplfuncsTest.php
+++ b/tests/unit/TplfuncsTest.php
@@ -149,9 +149,6 @@ class TplfuncsTest extends TestCase
      * Tests the link to the previous page.
      *
      * @return void
-     *
-     * @global array The localization of the core.
-     * @global int   The index of the requested page.
      */
     public function testPreviouspage()
     {
@@ -172,8 +169,6 @@ class TplfuncsTest extends TestCase
      * Tests that there's no link to the previous page if there is none.
      *
      * @return void
-     *
-     * @global int The index of the requested page.
      */
     public function testNoPreviousPage()
     {
@@ -190,9 +185,6 @@ class TplfuncsTest extends TestCase
      * Tests the link to the next page.
      *
      * @return void
-     *
-     * @global int   The index of the requested page.
-     * @global int   The number of pages.
      */
     public function testNextpage()
     {
@@ -214,9 +206,6 @@ class TplfuncsTest extends TestCase
      * Tests that there's no link to the next page if there is none.
      *
      * @return void
-     *
-     * @global int The index of the requested page.
-     * @global int The number of pages.
      */
     public function testNoNextPage()
     {
@@ -240,8 +229,6 @@ class TplfuncsTest extends TestCase
      * Tests languagemenu().
      *
      * @return void
-     *
-     * @global array The paths of system files and folders.
      */
     public function testLanguageMenu()
     {


### PR DESCRIPTION
The benefit of explicitly documenting which global variables are used
by a certain function (or method for that matter) is rather doubtful,
since we do not document other entities (functions, classes, constants)
which are used in a function either.  Furthermore, properly maintaining
these docs takes some time, and is prone to error nonetheless.  Also
these information could at least theoretically be automatically gained
from a static analysis tool.

It might make sense to document global variables which are modified by
a function, but we are not aware of any documentation tool actually
supporting `@global`.  At least neither Doxygen nor phpDocumentor do,
so we would have to work around this limitation to avoid broken docs.
This time is better spend to get rid of the globals altogether, or at
least encapsulate each in a single spot.

The situation regarding static function variables is somewhat similar.
`@staticvar` is not supported by the relevant documentation generators,
and it is a doubtful feature anyway.  It would be better to refactor
such functions to methods, and to turn the static function variables
into static class variables.

Therefore we rid all `@global` and `@staticvar` doc block comments
regarding functions and methods.  Of course, we keep the `@global`
doc block comments of the actual variables, of course.