### PR TITLE
Fix #283: Mailform should use fixed From address

### DIFF
--- a/cmsimple/classes/Mailform.php
+++ b/cmsimple/classes/Mailform.php
@@ -177,7 +177,8 @@ class Mailform
         global $cf, $tx;
 
         $this->mail->setTo($cf['mailform']['email']);
-        $this->mail->addHeader('From', $this->sender);
+        $this->mail->addHeader('From', $cf['mailform']['email']);
+        $this->mail->addHeader('Reply-To', $this->sender);
         $this->mail->addHeader('X-Remote', sv('REMOTE_ADDR'));
         $this->mail->setSubject($this->subject);
         $this->mail->setMessage(


### PR DESCRIPTION
Presently, mails sent via the built-in mailform use the submitted email
address as From header.  However, unknown senders may be blocked on
shared hosting servers, and therefore we set the From header to the
configured email address (which easily can be whitelisted, if
necessary), and set the Reply-To header to the submitted email address.