### PR TITLE
Fix #343: Fatal errors: nonsensical handling

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2533,13 +2533,21 @@ function XH_onShutdown()
         unset($_SESSION['xh_password']);
     }
 
-    if (error_reporting() <= 0) {
-        $lastError = error_get_last();
-        if (in_array($lastError['type'], array(E_ERROR, E_PARSE))) {
+    $lastError = error_get_last();
+    if (in_array($lastError['type'], array(E_ERROR, E_PARSE))) {
+        if (error_reporting() <= 0) {
             echo $tx['error']['fatal'];
+        } else {
+            printf(
+                '%s in <b>%s</b> on line <b>%d</b>',
+                nl2br($lastError['message']),
+                $lastError['file'],
+                $lastError['line']
+            );
         }
     }
 }
+
 /**
  * Returns a timestamp formatted according to config and lang.
  *


### PR DESCRIPTION
If an `E_PARSE` or `E_ERROR` error occurs, and debug mode is enabled,
we emit basically the same error message as PHP would have done, if
`display_errors` had been enabled.

We prefer this potential information leakage over letting the user
guess what has gone wrong, since debug mode is not supposed to be
enabled all the time in production environments, and since such kinds
of errors usually only happen after installing a new component or after
switching the PHP version, so the first to notice the problem is
hopefully the webmaster, anyway.  It also should be noticed, that
indeed only fatal errors will be shown this way, but not notices and
warnings, etc., what further limits the information leakage.