### PR TITLE
Fix #366: Search highlighting may break markup

### DIFF
--- a/assets/js/admin.min.js
+++ b/assets/js/admin.min.js
@@ -8,7 +8,7 @@
  * @license   GNU GPLv3 (http://www.gnu.org/licenses/gpl-3.0.en.html)
  * @since     1.6
  */
-var XH = {};
+var XH = XH || {};
 
 /**
  * Finds all elements with a certain class name.

--- a/assets/js/core.min.js
+++ b/assets/js/core.min.js
@@ -1,0 +1,79 @@
+/**
+ * Frontend JavaScript of CMSimple_XH
+ *
+ * <p>
+ * Parts based on Stuart Langridge's serchhi.js
+ * (https://kryogenix.org/code/browser/searchhi/)
+ * </p>
+ *
+ * @file
+ *
+ * @author    The CMSimple_XH developers <devs@cmsimple-xh.org>
+ * @copyright 2018 The CMSimple_XH developers (http://cmsimple-xh.org/?The_Team)
+ * @license   GNU GPLv3 (http://www.gnu.org/licenses/gpl-3.0.en.html)
+ * @since     1.7.3
+ */
+
+var XH = XH || {};
+
+/**
+ * Wraps all occurrences of word inside the given node in a
+ * &lt;span class="xh_find"&gt; element.
+ *
+ * @param {Node}   node
+ * @param {string} word
+ *
+ * @returns {undefined}
+ *
+ * @since 1.7.3
+ */
+XH.highlightSearchWord = function (node, word) {
+    var childNode, startIndex, i;
+
+    for (i = 0; i < node.childNodes.length; i++) {
+        childNode = node.childNodes[i];
+        if (!(childNode.className && childNode.className.match(/\xh_find\b/))) {
+            XH.highlightSearchWord(childNode, word);
+        }
+    }
+    if (node.nodeType === 3 /*Node.TEXT_NODE*/) {
+        startIndex = node.nodeValue.toLowerCase().indexOf(word);
+        if (startIndex !== -1) {
+            XH.doHighlightSearchWord(node, word, startIndex);
+        }
+    }
+};
+
+/**
+ * @private
+ */
+XH.doHighlightSearchWord = function (node, word, startIndex) {
+    var parentNode = node.parentNode;
+    var nodeValue = node.nodeValue;
+    var text1 = nodeValue.substr(0, startIndex);
+    var text2 = nodeValue.substr(startIndex, word.length);
+    var text3 = nodeValue.substr(startIndex + word.length);
+    var hiword = document.createElement("span");
+
+    hiword.className = "xh_find";
+    hiword.appendChild(document.createTextNode(text2));
+
+    parentNode.insertBefore(document.createTextNode(text1), node);
+    parentNode.insertBefore(hiword, node);
+    parentNode.insertBefore(document.createTextNode(text3), node);
+    parentNode.removeChild(node);
+
+};
+
+(function () {
+    var word, i;
+
+    if (XH.searchWords) {
+        for (i = 0; i < XH.searchWords.length; i++) {
+            word = XH.searchWords[i];
+            if (word) {
+                XH.highlightSearchWord(document.body, word.toLowerCase());
+            }
+        }
+    }
+}());

--- a/build.xml
+++ b/build.xml
@@ -96,7 +96,7 @@
     </target>
 
     <target name="js-doc">
-        <exec command="jsdoc --destination doc/js assets/js/admin.min.js"
+        <exec command="jsdoc --destination doc/js assets/js/"
               passthru="true" checkreturn="true"/>
     </target>
 
@@ -124,6 +124,7 @@
         </move>
         <jsMin targetDir="dist/cmsimplexh" suffix="" failOnError="false">
             <fileset dir="export">
+                <include name="assets/js/core.min.js"/>
                 <include name="assets/js/admin.min.js"/>
                 <include name="plugins/filebrowser/js/filebrowser.min.js"/>
                 <include name="plugins/meta_tags/metatags.min.js"/>

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -345,6 +345,7 @@ $pth['file']['pagedata'] = $pth['folder']['content'] . 'pagedata.php';
 $pth['file']['language'] = $pth['folder']['language'] . basename($sl) . '.php';
 $pth['folder']['corestyle'] = $pth['folder']['base'] . 'assets/css/';
 $pth['file']['corestyle'] = $pth['folder']['corestyle'] . 'core.css';
+$pth['file']['corejs'] = $pth['folder']['base'] . 'assets/js/core.min.js';
 $pth['file']['adminjs'] = $pth['folder']['base'] . 'assets/js/admin.min.js';
 
 XH_createLanguageFile($pth['file']['language']);

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -455,21 +455,23 @@ function editmenu()
  * Returns the contents area.
  *
  * @return string HTML
- *
- * @global int    The index of the current page.
- * @global string The output of the contents area.
- * @global array  The content of the pages.
- * @global bool   Whether edit mode is active.
  */
 function content()
 {
-    global $s, $o, $c, $edit;
+    global $s, $o, $c, $edit, $bjs, $pth;
 
     if (!($edit && XH_ADM) && $s > -1) {
         if (isset($_GET['search'])) {
             $search = XH_hsc(trim(preg_replace('/\s+/u', ' ', (stsl($_GET['search'])))));
-            $words = explode(' ', $search);
-            $c[$s] = XH_highlightSearchWords($words, $c[$s]);
+            $words = array_unique(explode(' ', $search));
+            usort($words, function ($a, $b) {
+                return strlen($b) - strlen($a);
+            });
+            $words = json_encode($words);
+            $bjs .= <<<HTML
+<script type="text/javascript" >var XH = XH || {}; XH.searchWords = $words;</script>
+<script type="text/javascript" src="{$pth['file']['corejs']}"></script>
+HTML;
         }
         $o .= preg_replace('/#CMSimple (.*?)#/is', '', $c[$s]);
     }


### PR DESCRIPTION
HTML manipulation with regular expressions is too error prone, as the
bug report shows; manipulating the DOM is way more resilient.  Since
the highlighting of the search strings is not a fundamental property of
CMSimple_XH, we change it to be done as progressive enhancement.

We're using a JavaScript routine which is based on Stuart Langridge's
serchhi.js[1], but use only those parts which we really need.  We also
refactor these parts according to our needs.  Since we still support
IE8 for the back-end, we stick with this for the front-end search
highlighting.  We also do not want to move functionality from
admin.min.js to core.min.js in a patch version, so we write even more
clumsy code which we should refactor for XH 1.8.

[1] <https://kryogenix.org/code/browser/searchhi/>