### PR TITLE
Disable Xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
 install:
     - if [[ ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then pecl install runkit; fi
     - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then pecl install uopz; fi
+    - phpenv config-rm xdebug.ini
     - composer install
 before_script:
     - export PATH=vendor/bin:$PATH


### PR DESCRIPTION
The CI doesn't need it, and recent versions clash with recent versions
of uopz[1], but we need the latter, so we just disable Xdebug.

[1] <https://github.com/krakjoe/uopz/issues/122>