### PR TITLE
Fix test failures

### DIFF
--- a/tests/unit/HeadTest.php
+++ b/tests/unit/HeadTest.php
@@ -159,16 +159,15 @@ class HeadTest extends TestCase
      */
     public function testRendersPrevLink()
     {
-        global $sn, $u;
-
-        $sn = '/xh/';
-        $u = array('Welcome');
         $findPreviousPageMock = $this->createFunctionMock('XH_findPreviousPage');
         $findPreviousPageMock->expects($this->any())->willReturn(0);
+        $getPageUrlMock = $this->createFunctionMock('XH_getPageURL');
+        $getPageUrlMock->expects($this->any())->willReturn('/xh/?previous');
         $this->assertXPath(
-            '//link[@rel="prev" and @href="/xh/?Welcome"]',
+            '//link[@rel="prev" and @href="/xh/?previous"]',
             head()
         );
+        $getPageUrlMock->restore();
         $findPreviousPageMock->restore();
     }
 
@@ -179,16 +178,15 @@ class HeadTest extends TestCase
      */
     public function testRendersNextLink()
     {
-        global $sn, $u;
-
-        $sn = '/xh/';
-        $u = array('Welcome');
         $findNextPageMock = $this->createFunctionMock('XH_findNextPage');
         $findNextPageMock->expects($this->any())->willReturn(0);
+        $getPageUrlMock = $this->createFunctionMock('XH_getPageURL');
+        $getPageUrlMock->expects($this->any())->willReturn('/xh/?next');
         $this->assertXPath(
-            '//link[@rel="next" and @href="/xh/?Welcome"]',
+            '//link[@rel="next" and @href="/xh/?next"]',
             head()
         );
+        $getPageUrlMock->restore();
         $findNextPageMock->restore();
     }
 
@@ -199,9 +197,12 @@ class HeadTest extends TestCase
      */
     public function testRendersTemplateStylesheetLink()
     {
+        $getPageUrlMock = $this->createFunctionMock('XH_getPageURL');
+        $getPageUrlMock->expects($this->any())->willReturn('some URL');
         $this->assertXPath(
             '//link[@rel="stylesheet" and @type="text/css" and @href="stylesheet"]',
             head()
         );
+        $getPageUrlMock->restore();
     }
 }

--- a/tests/unit/LocatorModelTest.php
+++ b/tests/unit/LocatorModelTest.php
@@ -84,7 +84,7 @@ class LocatorModelTest extends TestCase
 
         $s = 0;
         $title = $h[$s];
-        $this->assertEquals(array(array('foo', '?foo')), XH_getLocatorModel());
+        $this->assertEquals(array(array('foo', '')), XH_getLocatorModel());
     }
 
     public function testDressesPage()
@@ -94,7 +94,7 @@ class LocatorModelTest extends TestCase
         $s = 1;
         $title = $h[$s];
         $this->assertEquals(
-            array(array('Home', '?foo'), array('Dresses', '?Dresses')),
+            array(array('Home', ''), array('Dresses', '?Dresses')),
             XH_getLocatorModel()
         );
     }
@@ -107,7 +107,7 @@ class LocatorModelTest extends TestCase
         $title = $h[$s];
         $this->assertEquals(
             array(
-                array('Home', '?foo'),
+                array('Home', ''),
                 array('Dresses', '?Dresses'),
                 array('Real Dresses', '?Dresses/Real-Dresses')
             ),
@@ -131,7 +131,7 @@ class LocatorModelTest extends TestCase
         $s = 1;
         $title = 'Suits';
         $this->assertEquals(
-            array(array('Home', '?foo'), array('Suits', null)),
+            array(array('Home', ''), array('Suits', null)),
             XH_getLocatorModel()
         );
     }
@@ -173,7 +173,7 @@ class LocatorModelTest extends TestCase
         $title = $h[$s];
         $cf['show_hidden']['path_locator'] = 'true';
         $this->assertEquals(
-            array(array('Home', '?foo'), array('News', '?News')),
+            array(array('Home', ''), array('News', '?News')),
             XH_getLocatorModel()
         );
     }

--- a/tests/unit/TplfuncsTest.php
+++ b/tests/unit/TplfuncsTest.php
@@ -148,17 +148,19 @@ class TplfuncsTest extends TestCase
      */
     public function testPreviouspage()
     {
-        global $tx, $s;
+        global $tx;
 
-        $s = 10;
-        $hideMock = $this->createFunctionMock('hide');
-        $hideMock->expects($this->any())->willReturn(false);
+        $findPreviousPageMock = $this->createFunctionMock('XH_findPreviousPage');
+        $findPreviousPageMock->expects($this->any())->willReturn(1);
+        $getPageUrlMock = $this->createFunctionMock('XH_getPageURL');
+        $getPageUrlMock->expects($this->any())->willReturn('some URL');
         $this->assertXPathContains(
             '//a[@rel="prev"]',
             $tx['navigator']['previous'],
             previouspage()
         );
-        $hideMock->restore();
+        $getPageUrlMock->restore();
+        $findPreviousPageMock->restore();
     }
 
     /**
@@ -171,10 +173,10 @@ class TplfuncsTest extends TestCase
         global $s;
 
         $s = 10;
-        $hideMock = $this->createFunctionMock('hide');
-        $hideMock->expects($this->any())->willReturn(true);
+        $findPreviousPageMock = $this->createFunctionMock('XH_findPreviousPage');
+        $findPreviousPageMock->expects($this->any())->willReturn(false);
         $this->assertNull(previouspage());
-        $hideMock->restore();
+        $findPreviousPageMock->restore();
     }
 
     /**
@@ -184,18 +186,17 @@ class TplfuncsTest extends TestCase
      */
     public function testNextpage()
     {
-        global $s, $cl;
-
-        $s = 0;
-        $cl = 10;
-        $hideMock = $this->createFunctionMock('hide');
-        $hideMock->expects($this->any())->willReturn(false);
+        $findNextPageMock = $this->createFunctionMock('XH_findNextPage');
+        $findNextPageMock->expects($this->any())->willReturn(1);
+        $getPageUrlMock = $this->createFunctionMock('XH_getPageURL');
+        $getPageUrlMock->expects($this->any())->willReturn('some URL');
         $this->assertXPathContains(
             '//a[@rel="next"]',
             'next', /*$tx['navigator']['next']*/
             nextpage()
         );
-        $hideMock->restore();
+        $getPageUrlMock->restore();
+        $findNextPageMock->restore();
     }
 
     /**
@@ -205,14 +206,10 @@ class TplfuncsTest extends TestCase
      */
     public function testNoNextPage()
     {
-        global $s, $cl;
-
-        $s = 0;
-        $cl = 10;
-        $hideMock = $this->createFunctionMock('hide');
-        $hideMock->expects($this->any())->willReturn(true);
+        $findNextPageMock = $this->createFunctionMock('XH_findNextPage');
+        $findNextPageMock->expects($this->any())->willReturn(false);
         $this->assertNull(nextpage());
-        $hideMock->restore();
+        $findNextPageMock->restore();
     }
 
     public function testTop()


### PR DESCRIPTION
We have to adjust several tests, because the URL of the first page is
now suppressed[1].  Particularly, `XH_getPageURL()` is now called in
`nextpage()` and `previouspage()`, instead of accessing the usual
global variables, so we mock that function.

[1] <https://github.com/cmsimple-xh/cmsimple-xh/commit/7bfa1e04dad1b702b2e6998ff3213cc5888bed05>