### PR TITLE
Use version_compare() instead of casting to float

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -288,7 +288,7 @@ HTML;
         false, $stx['timezone']
     );
     $checks['other'][] = array(
-        (float)phpversion()>=5.4||!get_magic_quotes_runtime(), false, $stx['magic_quotes']
+        version_compare(PHP_VERSION, '5.4', '>=') || !get_magic_quotes_runtime(), false, $stx['magic_quotes']
     );
     $checks['other'][] = array(
         !ini_get('safe_mode'), false, $stx['safe_mode']

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -580,7 +580,7 @@ function rmanl($t)
  */
 function stsl($t)
 {
-    return ((float)phpversion()<5.4 && get_magic_quotes_gpc()) ? stripslashes($t) : $t;
+    return (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc()) ? stripslashes($t) : $t;
 }
 
 /**


### PR DESCRIPTION
While the `(float)` cast is not wrong per se, it feels rather hackish,
since the PHP version number is not a floating point value.  Using
`version_compare()` is much cleaner, and also easier to grep, when the
time comes to remove these checks altogether.