### PR TITLE
Fix attack tests

### DIFF
--- a/tests/attack/CSRFAttackTest.php
+++ b/tests/attack/CSRFAttackTest.php
@@ -48,7 +48,7 @@ class CSRFAttackTest extends PHPUnit_Framework_TestCase
      */
     protected function setCurlOptions($fields)
     {
-        if (defined('CURLOPT_SAFE_UPLOAD')) {
+        if (defined('CURLOPT_SAFE_UPLOAD') && version_compare(PHP_VERSION, '7.0', '<')) {
             curl_setopt($this->curlHandle, CURLOPT_SAFE_UPLOAD, false);
         }
         $options = array(
@@ -57,7 +57,7 @@ class CSRFAttackTest extends PHPUnit_Framework_TestCase
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_COOKIEFILE => $this->cookieFile
         );
-        @curl_setopt_array($this->curlHandle, $options);
+        curl_setopt_array($this->curlHandle, $options);
     }
 
     public function dataForAttack()
@@ -165,7 +165,9 @@ class CSRFAttackTest extends PHPUnit_Framework_TestCase
             ),
             array( // filebrowser: upload file
                 array(
-                    'fbupload' => '@' . realpath('./tests/attack/data/hack.txt'),
+                    'fbupload' => version_compare(PHP_VERSION, '7.0', '>=')
+                        ? new CURLFile(realpath('./tests/attack/data/hack.txt'))
+                        : '@' . realpath('./tests/attack/data/hack.txt'),
                     'upload' => 'upload'
                 ),
                 '&downloads'
@@ -197,7 +199,9 @@ class CSRFAttackTest extends PHPUnit_Framework_TestCase
             ),
             array( // editorbrowser: upload file
                 array(
-                    'fbupload' => '@' . realpath('./tests/attack/data/hack.txt'),
+                    'fbupload' => version_compare(PHP_VERSION, '7.0', '>=')
+                        ? new CURLFile(realpath('./tests/attack/data/hack.txt'))
+                        : '@' . realpath('./tests/attack/data/hack.txt'),
                     'upload' => 'upload'
                 ),
                 '&filebrowser=editorbrowser&editor=tinymce&prefix=./&base=./&type=image'


### PR DESCRIPTION
As of PHP 7.0.0, disabling safe uploads via `CURLOPT_SAFE_UPLOAD`is no
longer supported; instead files to be uploaded should be passed as
`CURLFile`.