### PR TITLE
Use namespaced PHPUnit TestCase instead pseudo namespaced alias

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,7 +11,7 @@
 
 namespace XH;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
 
 class TestCase extends PHPUnit_Framework_TestCase
 {

--- a/tests/attack/CSRFAttackTest.php
+++ b/tests/attack/CSRFAttackTest.php
@@ -12,6 +12,8 @@
  * @see       http://cmsimple-xh.org/
  */
 
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
+
 /**
  * A test case to actually check the CSRF protection.
  *

--- a/tests/attack/DOSAttackTest.php
+++ b/tests/attack/DOSAttackTest.php
@@ -12,6 +12,8 @@
  * @see       http://cmsimple-xh.org/
  */
 
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
+
 /**
  * A test case to check DOS attack prevention.
  *

--- a/tests/attack/XSSAttackTest.php
+++ b/tests/attack/XSSAttackTest.php
@@ -12,6 +12,8 @@
  * @see       http://cmsimple-xh.org/
  */
 
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
+
 /**
  * A test case to check XSS attack prevention.
  *


### PR DESCRIPTION
The alias `PHPUnit_Framework_TestCase` is no longer supported as of
PHPUnit 6, so we switch to `PHPUnit\Framework\TestCase` for forward
compatibility.