### PR TITLE
Remove unused local references to global variables

### DIFF
--- a/cmsimple/classes/Search.php
+++ b/cmsimple/classes/Search.php
@@ -174,7 +174,7 @@ class Search
      */
     public function render()
     {
-        global $h, $u, $cf, $tx, $pd_router;
+        global $h, $cf, $tx, $pd_router;
 
         $cf['meta']['robots'] = 'noindex, nofollow';
         $o = '<h1>' . $tx['search']['result'] . '</h1>';

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -22,8 +22,6 @@
  */
 function XH_renderPrevLink()
 {
-    global $sn, $u;
-
     $index = XH_findPreviousPage();
     if ($index !== false) {
         return '<link rel="prev" href="' . XH_getPageURL($index) . '">';
@@ -41,8 +39,6 @@ function XH_renderPrevLink()
  */
 function XH_renderNextLink()
 {
-    global $sn, $u;
-
     $index = XH_findNextPage();
     if ($index !== false) {
         return '<link rel="next" href="' . XH_getPageURL($index) . '">';


### PR DESCRIPTION
These variables are no longer used as of commit afd0e9d[1] and commit
74f9dae, respectively.

[1] <https://github.com/cmsimple-xh/cmsimple-xh/commit/afd0e9d18f9aab64754cd6866815bdf58f26d642>
[2] <https://github.com/cmsimple-xh/cmsimple-xh/commit/74f9daeae586117a0be7402ead0c7ceec3d428e4>