### PR TITLE
Use the composer installed local phpunit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -53,7 +53,11 @@
     </target>
 
     <target name="unit-tests" description="runs all unit tests">
-        <exec command="phpunit --bootstrap tests/bootstrap.php tests/unit" passthru="true" checkreturn="true"/>
+        <exec executable="vendor/bin/phpunit" passthru="true" checkreturn="true">
+            <arg value="--bootstrap"/>
+            <arg file="tests/bootstrap.php"/>
+            <arg file="tests/unit"/>
+        </exec>
     </target>
 
     <target name="validation-tests" description="runs all validation tests">


### PR DESCRIPTION
For some reason, just executing `phpunit` calls the wrong executable,
so we use a relative path.  Since this doesn't work on Windows, we
rework to use `<arg>`s.