### PR TITLE
Adjust build target for reqcheck.php

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -166,6 +166,8 @@
 
         <move file="dist/cmsimplexh/userfiles/downloads/_XHdebug.txt" tofile="dist/cmsimplexh/userfiles/downloads/XHdebug.txt"/>
 
+        <echo file="dist/cmsimplexh/reqcheck.php">This file serves no purpose, and can be deleted.</echo>
+
         <zip destfile="CMSimple_XH-${version}.zip" basedir="dist"/>
         <delete dir="dist" quiet="true"/>
     </target>
@@ -213,6 +215,7 @@
         <delete includeemptydirs="true">
             <fileset dir="dist/cmsimplexh/templates" includes="**"/>
         </delete>
+        <echo file="dist/cmsimplexh/reqcheck.php">This file serves no purpose, and can be deleted.</echo>
         <zip destfile="CMSimple_XH-${version}-patch.zip" basedir="dist" includeemptydirs="false"/>
         <delete dir="patchee" quiet="true"/>
         <delete dir="current" quiet="true"/>

--- a/build.xml
+++ b/build.xml
@@ -100,6 +100,7 @@
         <move todir="dist">
             <fileset dir="export">
                 <include name="README*.txt"/>
+                <include name="reqcheck.php"/>
             </fileset>
             <filterchain>
                 <replacetokens>
@@ -123,7 +124,6 @@
                 <include name="cmsimple/functions.php"/>
                 <include name="cmsimple/classes/Search.php"/>
                 <include name="plugins/filebrowser/admin.php"/>
-                <include name="plugins/tinymce/admin.php"/>
             </fileset>
             <filterchain>
                 <replacetokens>

--- a/reqcheck.php
+++ b/reqcheck.php
@@ -24,7 +24,7 @@ if (isset($_GET['phpinfo'])) {
     exit;
 }
 
-$version = 'CMSimple_XH 1.7.3';
+$version = '@CMSIMPLE_XH_VERSION@';
 $title = "$version – Requirements Check";
 
 $checks = array();


### PR DESCRIPTION
The distribution packages should have reqcheck.php outside of
cmsimplexh/, because the script is not actually part of the CMS.  We
also use a placeholder for the CMSimple_XH version, and fill that in
during build time.

While we're at it, we also remove the extraneous replacement of the
placeholder for the old tinymce plugin, which is superseeded by
tinymce4 as of CMSimple_XH 1.7.0.