### PR TITLE
Fix #366: Search highlighting may break markup

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2456,10 +2456,20 @@ function XH_highlightSearchWords(array $words, $text)
     foreach ($words as $word) {
         $word = trim($word);
         if ($word != '') {
-            $patterns[] = '/' . preg_quote($word, '/') . '(?![^<]*>)/isuU';
+            $patterns[] = '/(?:<(?:"[^"]*?"|[^>]*?)*>|(' . preg_quote($word, '/') . ')|&[^;]*;)/isu';
         }
     }
-    return preg_replace($patterns, '<span class="xh_find">$0</span>', $text);
+    return preg_replace_callback(
+        $patterns,
+        function ($matches) {
+            if (!isset($matches[1])) {
+                return $matches[0];
+            } else {
+                return "<span class=\"xh_find\">{$matches[1]}</span>";
+            }
+        },
+        $text
+    );
 }
 
 /**

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -790,7 +790,33 @@ class FunctionsTest extends TestCase
             [
                 ['word', 'word'], 'foo word bar',
                 'foo <span class="xh_find">word</span> bar'
-            ]
+            ],
+            // searching for entity names must not highlight
+            [
+                ['lt'], '<div>Standard text, paragraphs, heading &lt;h2&gt;</div>',
+                '<div>Standard text, paragraphs, heading &lt;h2&gt;</div>'
+            ],
+            // searching must not highlight inside of tags
+            // cf. <https://cmsimpleforum.com/viewtopic.php?f=10&t=14178>
+            [
+                ['emil'],
+                '<a href="userfiles/images/billedudlaan/k47_emil_nielsen/wtrmrk/2.jpg"'
+                . ' rel="prettyPhoto[imgalbum0]" title="566 - 50x60 cm<br />">'
+                . '<img src="userfiles/images/billedudlaan/k47_emil_nielsen/thumb/imgalbum_2.jpg"'
+                . ' class="thumb" alt="" title="" width="135" height="113"></a>',
+                '<a href="userfiles/images/billedudlaan/k47_emil_nielsen/wtrmrk/2.jpg"'
+                . ' rel="prettyPhoto[imgalbum0]" title="566 - 50x60 cm<br />">'
+                . '<img src="userfiles/images/billedudlaan/k47_emil_nielsen/thumb/imgalbum_2.jpg"'
+                . ' class="thumb" alt="" title="" width="135" height="113"></a>'
+            ],
+            // searching for "<" and ">"
+            [
+                ['&lt;code&gt;'],
+                'blah blah <code>&lt;code&gt;some code&lt;/code&gt;</code>'
+                . ' yada yada',
+                'blah blah <code><span class="xh_find">&lt;code&gt;</span>some code&lt;/code&gt;</code>'
+                . ' yada yada'
+            ],
         ];
     }
 


### PR DESCRIPTION
When highlighting search results, we must neither search inside of
tags, nor inside of entity references.