### PR TITLE
Bump requirements to PHP 5.5.0

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -289,9 +289,6 @@ HTML;
         false, $stx['timezone']
     );
     $checks['other'][] = array(
-        version_compare(PHP_VERSION, '5.4', '>=') || !get_magic_quotes_runtime(), false, $stx['magic_quotes']
-    );
-    $checks['other'][] = array(
         !ini_get('safe_mode'), false, $stx['safe_mode']
     );
     $checks['other'][] = array(
@@ -406,7 +403,7 @@ function XH_backupsView()
 
     $o = '<ul>' . "\n";
     if (isset($_GET['xh_success'])) {
-        $o .= XH_message('success', $tx['message'][stsl($_GET['xh_success'])]);
+        $o .= XH_message('success', $tx['message'][$_GET['xh_success']]);
     }
     $o .= '<li>' . utf8_ucfirst($tx['filetype']['content']) . ' <a href="'
         . $sn . '?file=content&amp;action=view" target="_blank">'
@@ -474,8 +471,7 @@ function XH_pluginsView()
     $hiddenPlugins = explode(',', $cf['plugins']['hidden']);
     $hiddenPlugins = array_map('trim', $hiddenPlugins);
     $plugins = array_diff($plugins, $hiddenPlugins);
-    natcasesort($plugins);
-    $plugins = array_values($plugins);
+    sort($plugins, SORT_NATURAL | SORT_FLAG_CASE);
 
     $o = '<h1>' . $tx['title']['plugins'] . '</h1><ul>';
     foreach ($plugins as $plugin) {
@@ -647,8 +643,7 @@ function XH_adminMenu(array $plugins = array())
     $rows = ceil($total / $columns);
     $width = 150 * $columns;
     $marginLeft = min($width, 300) - $width;
-    natcasesort($plugins);
-    $plugins = array_values($plugins);
+    sort($plugins, SORT_NATURAL | SORT_FLAG_CASE);
     $orderedPlugins = array();
     for ($j = 0; $j < $rows; ++$j) {
         for ($i = 0; $i < $total; $i += $rows) {
@@ -910,16 +905,13 @@ function XH_saveEditorContents($text)
     //clean up and inject split-markers
     if (!$cf['mode']['advanced']) {
         $text = preg_replace('/<!--XH_ml[1-9]:.*?-->/isu', '', $text);
-        $split = '<!--XH_ml' . stsl($_POST['level']) . ':'
-            . stsl($_POST['heading']) . '-->'
+        $split = '<!--XH_ml' . $_POST['level'] . ':'
+            . $_POST['heading'] . '-->'
             . "\n";
         $text = $split . $text;
     }
     $hot = '<!--XH_ml[1-9]:';
     $hct = '-->';
-    // TODO: this might be done before the plugins are loaded
-    //       for backward compatibility
-    $text = stsl($text);
     // remove empty headings
     $text = preg_replace("/$hot(&nbsp;|&#160;|\xC2\xA0| )?$hct/isu", '', $text);
     // replace P elements around plugin calls and scripting with DIVs

--- a/cmsimple/classes/ArrayFileEdit.php
+++ b/cmsimple/classes/ArrayFileEdit.php
@@ -202,7 +202,7 @@ abstract class ArrayFileEdit extends FileEdit
         $value = utf8_ucfirst($tx['action']['save']);
         $button = '<input type="submit" class="submit" value="' . $value . '">';
         if (isset($_GET['xh_success'])) {
-            $filetype = utf8_ucfirst($tx['filetype'][stsl($_GET['xh_success'])]);
+            $filetype = utf8_ucfirst($tx['filetype'][$_GET['xh_success']]);
             $message = XH_message('success', $tx['message']['saved'], $filetype);
         } else {
             $message = '';
@@ -289,7 +289,7 @@ abstract class ArrayFileEdit extends FileEdit
         foreach ($this->cfg as $cat => $opts) {
             foreach ($opts as $name => $opt) {
                 $iname = XH_FORM_NAMESPACE . $cat . '_' . $name;
-                $val = isset($_POST[$iname]) ? stsl($_POST[$iname]) : '';
+                $val = isset($_POST[$iname]) ? $_POST[$iname] : '';
                 if ($opt['type'] == 'bool') {
                     $val = isset($_POST[$iname]) ? 'true' : '';
                 } elseif ($opt['type'] == 'random') {

--- a/cmsimple/classes/ChangePassword.php
+++ b/cmsimple/classes/ChangePassword.php
@@ -65,11 +65,11 @@ class ChangePassword
         global $cf, $tx, $_XH_csrfProtection;
 
         $this->passwordOld = isset($_POST['xh_password_old'])
-            ? stsl($_POST['xh_password_old']) : '';
+            ? $_POST['xh_password_old'] : '';
         $this->passwordNew = isset($_POST['xh_password_new'])
-            ? stsl($_POST['xh_password_new']) : '';
+            ? $_POST['xh_password_new'] : '';
         $this->passwordConfirmation = isset($_POST['xh_password_confirmation'])
-            ? stsl($_POST['xh_password_confirmation']) : '';
+            ? $_POST['xh_password_confirmation'] : '';
         $this->config = $cf;
         $this->lang = $tx;
         $this->csrfProtector = $_XH_csrfProtection;

--- a/cmsimple/classes/Controller.php
+++ b/cmsimple/classes/Controller.php
@@ -64,7 +64,7 @@ class Controller
     {
         global $search;
 
-        return new Search(stsl($search));
+        return new Search($search);
     }
 
     /**
@@ -151,7 +151,7 @@ class Controller
         global $adm, $login, $logout, $keycut, $f;
 
         $adm = gc('status') == 'adm' && logincheck();
-        $keycut = stsl($keycut);
+        $keycut = $keycut;
         if ($login && $keycut == '' && !$adm) {
             $login = null;
             $f = 'login';
@@ -319,7 +319,6 @@ class Controller
         $_XH_csrfProtection->check();
         $postData = $_POST;
         unset($postData['save_page_data'], $postData['xh_csrf_token']);
-        $postData = array_map('stsl', $postData);
         $successful = $pd_router->update($s, $postData);
         if (isset($_GET['xh_pagedata_ajax'])) {
             if ($successful) {
@@ -390,7 +389,7 @@ class Controller
 
         $_XH_csrfProtection->check();
         if ($file == 'content') {
-            $suffix = stsl($_POST['xh_suffix']);
+            $suffix = $_POST['xh_suffix'];
             if (preg_match('/^[a-z_0-9-]{1,20}$/i', $suffix)) {
                 XH_extraBackup($suffix);
             }

--- a/cmsimple/classes/CoreArrayFileEdit.php
+++ b/cmsimple/classes/CoreArrayFileEdit.php
@@ -66,7 +66,7 @@ abstract class CoreArrayFileEdit extends ArrayFileEdit
             }
             closedir($dh);
         }
-        natcasesort($options);
+        sort($options, SORT_NATURAL | SORT_FLAG_CASE);
         return $options;
     }
 }

--- a/cmsimple/classes/Mailform.php
+++ b/cmsimple/classes/Mailform.php
@@ -93,20 +93,20 @@ class Mailform
 
         $this->embedded = $embedded;
         $this->sendername = isset($_POST['sendername'])
-            ? stsl($_POST['sendername']) : '';
+            ? $_POST['sendername'] : '';
         $this->senderphone = isset($_POST['senderphone'])
-            ? stsl($_POST['senderphone']) : '';
+            ? $_POST['senderphone'] : '';
         $this->sender = isset($_POST['sender'])
-            ? stsl($_POST['sender']) : '';
+            ? $_POST['sender'] : '';
         $this->getlast = isset($_POST['getlast'])
-            ? stsl($_POST['getlast']) : '';
+            ? $_POST['getlast'] : '';
         $this->cap = isset($_POST['cap'])
-            ? stsl($_POST['cap']) : '';
+            ? $_POST['cap'] : '';
             
         if (isset($_POST['subject'])) {
-            $this->subject = stsl($_POST['subject']);
+            $this->subject = $_POST['subject'];
         } elseif (isset($_GET['xh_mailform_subject'])) {
-            $this->subject = stsl($_GET['xh_mailform_subject']);
+            $this->subject = $_GET['xh_mailform_subject'];
         } elseif (isset($subject)) {
             $this->subject = $subject;
         } else {
@@ -115,10 +115,10 @@ class Mailform
             
         if ($embedded) {
             $this->mailform = isset($_POST['xh_mailform'])
-                ? stsl($_POST['xh_mailform']) : '';
+                ? $_POST['xh_mailform'] : '';
         } else {
             $this->mailform = isset($_POST['mailform'])
-                ? stsl($_POST['mailform']) : '';
+                ? $_POST['mailform'] : '';
         }
         $this->mail = isset($mail) ? $mail : new Mail();
     }

--- a/cmsimple/classes/TextFileEdit.php
+++ b/cmsimple/classes/TextFileEdit.php
@@ -56,7 +56,7 @@ abstract class TextFileEdit extends FileEdit
         $action = isset($this->plugin) ? $sn . '?&amp;' . $this->plugin : $sn;
         $value = utf8_ucfirst($tx['action']['save']);
         if (isset($_GET['xh_success'])) {
-            $filetype = utf8_ucfirst($tx['filetype'][stsl($_GET['xh_success'])]);
+            $filetype = utf8_ucfirst($tx['filetype'][$_GET['xh_success']]);
             $message =  XH_message('success', $tx['message']['saved'], $filetype);
         } else {
             $message = '';
@@ -90,7 +90,7 @@ abstract class TextFileEdit extends FileEdit
         global $_XH_csrfProtection;
 
         $_XH_csrfProtection->check();
-        $this->text = stsl($_POST[$this->textareaName]);
+        $this->text = $_POST[$this->textareaName];
         if ($this->save() !== false) {
             header('Location: ' . CMSIMPLE_URL . $this->redir, true, 303);
             XH_exit();

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -243,7 +243,7 @@ require_once $pth['folder']['cmsimple'] . 'functions.php';
 spl_autoload_register('XH_autoload');
 require_once $pth['folder']['cmsimple'] . 'tplfuncs.php';
 require_once $pth['folder']['cmsimple'] . 'utf8.php';
-if (!function_exists('password_hash') || !function_exists('random_bytes')) {
+if (!function_exists('random_bytes')) {
     include_once $pth['folder']['cmsimple'] . 'password.php';
 }
 require_once $pth['folder']['cmsimple'] . 'seofuncs.php';
@@ -805,7 +805,7 @@ if (!isset($cf['uri']['length'])) {
 $su = utf8_substr($su, 0, $cf['uri']['length']);
 
 if ($download != '') {
-    download($pth['folder']['downloads'] . basename(stsl($download)));
+    download($pth['folder']['downloads'] . basename($download));
 }
 
 $pth['file']['search'] = $pth['folder']['cmsimple'] . 'search.php';

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -572,15 +572,17 @@ function rmanl($t)
  * Returns the un-quoted $t, i.e. reverses the effect
  * of magic_quotes_gpc/magic_quotes_sybase.
  *
- * If in doubt, use on all user input (but at most once!).
+ * Since magic_quotes are gone, it is a NOP now.
  *
  * @param string $t A string.
  *
  * @return string
+ *
+ * @deprecated since 1.8
  */
 function stsl($t)
 {
-    return (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc()) ? stripslashes($t) : $t;
+    return $t;
 }
 
 /**
@@ -1342,8 +1344,6 @@ function pluginFiles($plugin)
  * @since 1.6
  *
  * @todo Might be optimized to set $admPlugins only when necessary.
- * @todo with PHP 5.4.0 replace array_values()
- *       by sort($plugins, SORT_NATURAL | SORT_FLAG_CASE)
  */
 function XH_plugins($admin = false)
 {
@@ -1371,10 +1371,8 @@ function XH_plugins($admin = false)
             }
             closedir($dh);
         }
-        natcasesort($plugins);
-        $plugins = array_values($plugins);
-        natcasesort($admPlugins);
-        $admPlugins = array_values($admPlugins);
+        sort($plugins, SORT_NATURAL | SORT_FLAG_CASE);
+        sort($admPlugins, SORT_NATURAL | SORT_FLAG_CASE);
     }
     return $admin ? $admPlugins : $plugins;
 }
@@ -1869,7 +1867,7 @@ function XH_templates()
         }
         closedir($handle);
     }
-    natcasesort($templates);
+    sort($templates, SORT_NATURAL | SORT_FLAG_CASE);
     return $templates;
 }
 
@@ -1893,7 +1891,7 @@ function XH_availableLocalizations()
         }
         closedir($handle);
     }
-    natcasesort($languages);
+    sort($languages, SORT_NATURAL | SORT_FLAG_CASE);
     return $languages;
 }
 
@@ -2073,8 +2071,7 @@ function XH_lastJsonError()
 /**
  * Converts special characters to HTML entities.
  *
- * Same as htmlspecialchars($string, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8'),
- * but works for PHP < 5.4 as well.
+ * Same as htmlspecialchars($string, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8').
  *
  * @param string $string A string.
  *
@@ -2084,13 +2081,7 @@ function XH_lastJsonError()
  */
 function XH_hsc($string)
 {
-    if (!defined('ENT_SUBSTITUTE')) {
-        $string = utf8_bad_replace($string, "\xEF\xBF\xBD");
-        $string = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
-    } else {
-        $string = htmlspecialchars($string, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8');
-    }
-    return $string;
+    return htmlspecialchars($string, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8');
 }
 
 /**
@@ -2319,8 +2310,8 @@ function XH_registerPluginType($type, $plugin = null)
     } else {
         if (isset($plugins[$type])) {
             $result = $plugins[$type];
-            natcasesort($result);
-            return array_values($result);
+            sort($result, SORT_NATURAL | SORT_FLAG_CASE);
+            return $result;
         } else {
             return array();
         }

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -279,7 +279,6 @@ $tx['syscheck']['fail']="Fehler";
 $tx['syscheck']['fsockopen']="die Funktion fsockopen verfügbar ist";
 $tx['syscheck']['locale_available']="Locale '%s' verfügbar ist";
 $tx['syscheck']['locale_default']="das Standard-Locale aktiv ist";
-$tx['syscheck']['magic_quotes']="magic_quotes_runtime deaktiviert ist";
 $tx['syscheck']['message']="Prüfe, dass %1\$s … %2\$s";
 $tx['syscheck']['password']="das voreingestellte Passwort geändert wurde";
 $tx['syscheck']['phpversion']="die PHP-Version ≥ %s";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -279,7 +279,6 @@ $tx['syscheck']['fail']="failure";
 $tx['syscheck']['fsockopen']="function fsockopen is available";
 $tx['syscheck']['locale_available']="locale '%s' is available";
 $tx['syscheck']['locale_default']="default locale is in use";
-$tx['syscheck']['magic_quotes']="magic_quotes_runtime is off";
 $tx['syscheck']['message']="Checking that %1\$s … %2\$s";
 $tx['syscheck']['password']="non-default password is set";
 $tx['syscheck']['phpversion']="PHP version ≥ %s";

--- a/cmsimple/password.php
+++ b/cmsimple/password.php
@@ -10,360 +10,53 @@
  * @copyright 2012 The Authors
  */
 
-namespace {
-
-    if (!function_exists('random_bytes')) {
-        
-        /**
-         * @param int $length
-         * @return string
-         */
-        function random_bytes($length)
-        {
-            $buffer = '';
-            $buffer_valid = false;
-            if (function_exists('mcrypt_create_iv') && !defined('PHALANGER')) {
-                $buffer = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
-                if ($buffer) {
-                    $buffer_valid = true;
-                }
+if (!function_exists('random_bytes')) {
+    
+    /**
+     * @param int $length
+     * @return string
+     */
+    function random_bytes($length)
+    {
+        $buffer = '';
+        $buffer_valid = false;
+        if (function_exists('mcrypt_create_iv') && !defined('PHALANGER')) {
+            $buffer = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
+            if ($buffer) {
+                $buffer_valid = true;
             }
-            if (!$buffer_valid && function_exists('openssl_random_pseudo_bytes')) {
-                $strong = false;
-                $buffer = openssl_random_pseudo_bytes($length, $strong);
-                if ($buffer && $strong) {
-                    $buffer_valid = true;
-                }
-            }
-            if (!$buffer_valid && @is_readable('/dev/urandom')) {
-                $file = fopen('/dev/urandom', 'r');
-                $read = 0;
-                $local_buffer = '';
-                while ($read < $length) {
-                    $local_buffer .= fread($file, $length - $read);
-                    $read = PasswordCompat\binary\_strlen($local_buffer);
-                }
-                fclose($file);
-                if ($read >= $length) {
-                    $buffer_valid = true;
-                }
-                $buffer = str_pad($buffer, $length, "\0") ^ str_pad($local_buffer, $length, "\0");
-            }
-            if (!$buffer_valid || PasswordCompat\binary\_strlen($buffer) < $length) {
-                $buffer_length = PasswordCompat\binary\_strlen($buffer);
-                for ($i = 0; $i < $length; $i++) {
-                    if ($i < $buffer_length) {
-                        $buffer[$i] = $buffer[$i] ^ chr(mt_rand(0, 255));
-                    } else {
-                        $buffer .= chr(mt_rand(0, 255));
-                    }
-                }
-            }
-            return $buffer;
         }
-    }
-
-    if (!defined('PASSWORD_BCRYPT')) {
-        /**
-         * PHPUnit Process isolation caches constants, but not function declarations.
-         * So we need to check if the constants are defined separately from
-         * the functions to enable supporting process isolation in userland
-         * code.
-         */
-        define('PASSWORD_BCRYPT', 1);
-        define('PASSWORD_DEFAULT', PASSWORD_BCRYPT);
-        define('PASSWORD_BCRYPT_DEFAULT_COST', 10);
-    }
-
-    if (!function_exists('password_hash')) {
-
-        /**
-         * Hash the password using the specified algorithm
-         *
-         * @param string $password The password to hash
-         * @param int    $algo     The algorithm to use (Defined by PASSWORD_* constants)
-         * @param array  $options  The options for the algorithm to use
-         *
-         * @return string|false The hashed password, or false on error.
-         */
-        function password_hash($password, $algo, array $options = array())
-        {
-            if (!function_exists('crypt')) {
-                trigger_error("Crypt must be loaded for password_hash to function", E_USER_WARNING);
-                return null;
+        if (!$buffer_valid && function_exists('openssl_random_pseudo_bytes')) {
+            $strong = false;
+            $buffer = openssl_random_pseudo_bytes($length, $strong);
+            if ($buffer && $strong) {
+                $buffer_valid = true;
             }
-            if (is_null($password) || is_int($password)) {
-                $password = (string) $password;
-            }
-            if (!is_string($password)) {
-                trigger_error("password_hash(): Password must be a string", E_USER_WARNING);
-                return null;
-            }
-            if (!is_int($algo)) {
-                trigger_error(
-                    "password_hash() expects parameter 2 to be long, " . gettype($algo) . " given",
-                    E_USER_WARNING
-                );
-                return null;
-            }
-            $resultLength = 0;
-            switch ($algo) {
-                case PASSWORD_BCRYPT:
-                    $cost = PASSWORD_BCRYPT_DEFAULT_COST;
-                    if (isset($options['cost'])) {
-                        $cost = (int) $options['cost'];
-                        if ($cost < 4 || $cost > 31) {
-                            trigger_error(
-                                sprintf("password_hash(): Invalid bcrypt cost parameter specified: %d", $cost),
-                                E_USER_WARNING
-                            );
-                            return null;
-                        }
-                    }
-                    // The length of salt to generate
-                    $raw_salt_len = 16;
-                    // The length required in the final serialization
-                    $required_salt_len = 22;
-                    $hash_format = sprintf("$2y$%02d$", $cost);
-                    // The expected length of the final crypt() output
-                    $resultLength = 60;
-                    break;
-                default:
-                    trigger_error(
-                        sprintf("password_hash(): Unknown password hashing algorithm: %s", $algo),
-                        E_USER_WARNING
-                    );
-                    return null;
-            }
-            $salt_req_encoding = false;
-            if (isset($options['salt'])) {
-                switch (gettype($options['salt'])) {
-                    case 'NULL':
-                    case 'boolean':
-                    case 'integer':
-                    case 'double':
-                    case 'string':
-                        $salt = (string) $options['salt'];
-                        break;
-                    case 'object':
-                        if (method_exists($options['salt'], '__tostring')) {
-                            $salt = (string) $options['salt'];
-                            break;
-                        }
-                        // no break
-                    case 'array':
-                    case 'resource':
-                    default:
-                        trigger_error('password_hash(): Non-string salt parameter supplied', E_USER_WARNING);
-                        return null;
-                }
-                if (PasswordCompat\binary\_strlen($salt) < $required_salt_len) {
-                    trigger_error(
-                        sprintf(
-                            "password_hash(): Provided salt is too short: %d expecting %d",
-                            PasswordCompat\binary\_strlen($salt),
-                            $required_salt_len
-                        ),
-                        E_USER_WARNING
-                    );
-                    return null;
-                } elseif (0 == preg_match('#^[a-zA-Z0-9./]+$#D', $salt)) {
-                    $salt_req_encoding = true;
-                }
-            } else {
-                $salt = random_bytes($raw_salt_len);
-                $salt_req_encoding = true;
-            }
-            if ($salt_req_encoding) {
-                // encode string with the Base64 variant used by crypt
-                $base64_digits =
-                    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-                $bcrypt64_digits =
-                    './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-                $base64_string = base64_encode($salt);
-                $salt = strtr(rtrim($base64_string, '='), $base64_digits, $bcrypt64_digits);
-            }
-            $salt = PasswordCompat\binary\_substr($salt, 0, $required_salt_len);
-
-            $hash = $hash_format . $salt;
-
-            $ret = crypt($password, $hash);
-
-            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != $resultLength) {
-                return false;
-            }
-
-            return $ret;
         }
-
-    }
-
-    if (!function_exists('password_get_info')) {
-
-        /**
-         * Get information about the password hash. Returns an array of the information
-         * that was used to generate the password hash.
-         *
-         * array(
-         *    'algo' => 1,
-         *    'algoName' => 'bcrypt',
-         *    'options' => array(
-         *        'cost' => PASSWORD_BCRYPT_DEFAULT_COST,
-         *    ),
-         * )
-         *
-         * @param string $hash The password hash to extract info from
-         *
-         * @return array The array of information about the hash.
-         */
-        function password_get_info($hash)
-        {
-            $return = array(
-                'algo' => 0,
-                'algoName' => 'unknown',
-                'options' => array(),
-            );
-            if (PasswordCompat\binary\_substr($hash, 0, 4) == '$2y$' && PasswordCompat\binary\_strlen($hash) == 60) {
-                $return['algo'] = PASSWORD_BCRYPT;
-                $return['algoName'] = 'bcrypt';
-                list($cost) = sscanf($hash, "$2y$%d$");
-                $return['options']['cost'] = $cost;
+        if (!$buffer_valid && @is_readable('/dev/urandom')) {
+            $file = fopen('/dev/urandom', 'r');
+            $read = 0;
+            $local_buffer = '';
+            while ($read < $length) {
+                $local_buffer .= fread($file, $length - $read);
+                $read = strlen($local_buffer);
             }
-            return $return;
+            fclose($file);
+            if ($read >= $length) {
+                $buffer_valid = true;
+            }
+            $buffer = str_pad($buffer, $length, "\0") ^ str_pad($local_buffer, $length, "\0");
         }
-
-    }
-
-    if (!function_exists('password_needs_rehash')) {
-
-        /**
-         * Determine if the password hash needs to be rehashed according to the options provided
-         *
-         * If the answer is true, after validating the password using password_verify, rehash it.
-         *
-         * @param string $hash    The hash to test
-         * @param int    $algo    The algorithm used for new password hashes
-         * @param array  $options The options array passed to password_hash
-         *
-         * @return boolean True if the password needs to be rehashed.
-         */
-        function password_needs_rehash($hash, $algo, array $options = array())
-        {
-            $info = password_get_info($hash);
-            if ($info['algo'] !== (int) $algo) {
-                return true;
-            }
-            switch ($algo) {
-                case PASSWORD_BCRYPT:
-                    $cost = isset($options['cost']) ? (int) $options['cost'] : PASSWORD_BCRYPT_DEFAULT_COST;
-                    if ($cost !== $info['options']['cost']) {
-                        return true;
-                    }
-                    break;
-            }
-            return false;
-        }
-
-    }
-
-    if (!function_exists('password_verify')) {
-
-        /**
-         * Verify a password against a hash using a timing attack resistant approach
-         *
-         * @param string $password The password to verify
-         * @param string $hash     The hash to verify against
-         *
-         * @return boolean If the password matches the hash
-         */
-        function password_verify($password, $hash)
-        {
-            if (!function_exists('crypt')) {
-                trigger_error("Crypt must be loaded for password_verify to function", E_USER_WARNING);
-                return false;
-            }
-            $ret = crypt($password, $hash);
-            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != PasswordCompat\binary\_strlen($hash)
-                    || PasswordCompat\binary\_strlen($ret) <= 13) {
-                return false;
-            }
-
-            $status = 0;
-            for ($i = 0; $i < PasswordCompat\binary\_strlen($ret); $i++) {
-                $status |= (ord($ret[$i]) ^ ord($hash[$i]));
-            }
-
-            return $status === 0;
-        }
-    }
-
-}
-
-namespace PasswordCompat\binary {
-
-    if (!function_exists('PasswordCompat\\binary\\_strlen')) {
-
-        /**
-         * Count the number of bytes in a string
-         *
-         * We cannot simply use strlen() for this, because it might be overwritten by the mbstring extension.
-         * In this case, strlen() will count the number of *characters* based on the internal encoding. A
-         * sequence of bytes might be regarded as a single multibyte character.
-         *
-         * @param string $binary_string The input string
-         *
-         * @internal
-         * @return int The number of bytes
-         */
-        function _strlen($binary_string)
-        {
-            if (function_exists('mb_strlen')) {
-                return mb_strlen($binary_string, '8bit');
-            }
-            return strlen($binary_string);
-        }
-
-        /**
-         * Get a substring based on byte limits
-         *
-         * @see _strlen()
-         *
-         * @param string $binary_string The input string
-         * @param int    $start
-         * @param int    $length
-         *
-         * @internal
-         * @return string The substring
-         */
-        function _substr($binary_string, $start, $length)
-        {
-            if (function_exists('mb_substr')) {
-                return mb_substr($binary_string, $start, $length, '8bit');
-            }
-            return substr($binary_string, $start, $length);
-        }
-
-        /**
-         * Check if current PHP version is compatible with the library
-         *
-         * @return boolean the check result
-         */
-        function check()
-        {
-            static $pass = null;
-
-            if (is_null($pass)) {
-                if (function_exists('crypt')) {
-                    $hash = '$2y$04$usesomesillystringfore7hnbRJHxXVLeakoG8K30oukPsA.ztMG';
-                    $test = crypt("password", $hash);
-                    $pass = $test == $hash;
+        if (!$buffer_valid || strlen($buffer) < $length) {
+            $buffer_length = strlen($buffer);
+            for ($i = 0; $i < $length; $i++) {
+                if ($i < $buffer_length) {
+                    $buffer[$i] = $buffer[$i] ^ chr(mt_rand(0, 255));
                 } else {
-                    $pass = false;
+                    $buffer .= chr(mt_rand(0, 255));
                 }
             }
-            return $pass;
         }
-
+        return $buffer;
     }
 }

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -282,7 +282,7 @@ function XH_printUrl()
 
     $t = '&print';
     if ($f == 'search') {
-        $t .= '&function=search&search=' . urlencode(stsl($search));
+        $t .= '&function=search&search=' . urlencode($search);
     } elseif ($f == 'file') {
         $t .= '&file=' . $file;
     } elseif ($f != '' && $f != 'save') {

--- a/plugins/filebrowser/classes/Controller.php
+++ b/plugins/filebrowser/classes/Controller.php
@@ -253,8 +253,8 @@ class Controller
                 }
             }
             closedir($handle);
-            natcasesort($this->folders);
-            natcasesort($this->files);
+            sort($this->folders, SORT_NATURAL | SORT_FLAG_CASE);
+            sort($this->files, SORT_NATURAL | SORT_FLAG_CASE);
         }
     }
 
@@ -283,7 +283,7 @@ class Controller
                 }
             }
             closedir($handle);
-            natcasesort($folders);
+            sort($folders, SORT_NATURAL | SORT_FLAG_CASE);
         }
         return $folders;
     }

--- a/plugins/pagemanager/classes/Model.php
+++ b/plugins/pagemanager/classes/Model.php
@@ -134,7 +134,7 @@ class Model
                 }
             }
         }
-        natcasesort($themes);
+        sort($themes, SORT_NATURAL | SORT_FLAG_CASE);
         return $themes;
     }
 

--- a/reqcheck.php
+++ b/reqcheck.php
@@ -29,11 +29,10 @@ $title = "$version – Requirements Check";
 
 $checks = array();
 $checks['the Webserver is supported'] = preg_match('/apache|nginx|iis|litespeed/i', $_SERVER['SERVER_SOFTWARE']) ? 'okay' : 'warn';
-$checks['the PHP Version is at least 5.3.7'] = version_compare(PHP_VERSION, '5.3.7', '>=') ? 'okay' : 'fail';
+$checks['the PHP Version is at least 5.5.0'] = version_compare(PHP_VERSION, '5.5.0', '>=') ? 'okay' : 'fail';
 foreach (array('json', 'mbstring', 'session') as $ext) {
     $checks['the PHP extension "' . $ext . '" is installed'] = extension_loaded($ext) ? 'okay' : 'fail';
 }
-$checks['magic_quotes_runtime is off'] = (version_compare(PHP_VERSION, '5.4', '>=') || !get_magic_quotes_runtime()) ? 'okay' : 'warn';
 $checks['safe_mode is off'] = !ini_get('safe_mode') ? 'okay' : 'warn';
 $checks['session.use_trans_sid is off'] = !ini_get('session.use_trans_sid') ? 'okay' : 'warn';
 $checks['session.use_only_cookies is on'] = ini_get('session.use_only_cookies') ? 'okay' : 'warn';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,7 +45,7 @@ spl_autoload_register(function ($className) {
     }
 });
 
-if (!function_exists('password_hash') || !function_exists('random_bytes')) {
+if (!function_exists('random_bytes')) {
     include_once './cmsimple/password.php';
 }
 


### PR DESCRIPTION
PHP 5.5.0 has been released more than seven years ago, and even though
CentOS 7 (which has security support until June 2024) ships PHP 5.4 by
default, it seems to be prudent to assume that almost noone would be
left behind by requiring PHP 5.5.0.

The benefits of this move: we can remove almost all of password.php, we
can remove the magic quotes stuff (but keep the deprecated `stsl()`),
we can use `sort()` with the `SORT_NATURAL|SORT_FLAG_CASE` flag instead
of `array_values(natcasesort())`, we can nicely simplify `XH_hsc()`,
and there may be a lot more.