### PR TITLE
Check for availability of OpenSSL

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -249,6 +249,7 @@ HTML;
             array('intl', false),
             'json',
             'mbstring',
+            array('openssl', false),
             'session'
         ),
         'writable' => array(),

--- a/reqcheck.php
+++ b/reqcheck.php
@@ -33,6 +33,7 @@ $checks['the PHP Version is at least 5.3.7'] = version_compare(PHP_VERSION, '5.3
 foreach (array('json', 'mbstring', 'session') as $ext) {
     $checks['the PHP extension "' . $ext . '" is installed'] = extension_loaded($ext) ? 'okay' : 'fail';
 }
+$checks['the PHP extension "openssl" is installed'] = extension_loaded('openssl') ? 'okay' : 'warn';
 $checks['magic_quotes_runtime is off'] = (version_compare(PHP_VERSION, '5.4', '>=') || !get_magic_quotes_runtime()) ? 'okay' : 'warn';
 $checks['safe_mode is off'] = !ini_get('safe_mode') ? 'okay' : 'warn';
 $checks['session.use_trans_sid is off'] = !ini_get('session.use_trans_sid') ? 'okay' : 'warn';


### PR DESCRIPTION
While the OpenSSL extension is not strictly required, in practise it is
required for most update checks, and it offers a good solution for our
`random_bytes()` polyfill for PHP 5.  Thus, it seems to be prudent to
add a respective check to the system and requirements checks.