### PR TITLE
Improve support for soft hyphens in page headings

### DIFF
--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -40,6 +40,7 @@ $cf['plugins']['disabled']="";
 $cf['plugins']['hidden']="meta_tags,page_params";
 $cf['uri']['seperator']="/";
 $cf['uri']['word_separator']="-";
+$cf['uri']['soft_hyphen']="";
 $cf['uri']['length']="200";
 $cf['editmenu']['scroll']="";
 $cf['editmenu']['external']="";

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -768,7 +768,12 @@ function XH_readContents($language = null)
             $empty++;
             $temp = $tx['toc']['empty'] . ' ' . $empty;
         }
-        $h[] = $temp;
+        if (($softHyphen = trim($cf['uri']['soft_hyphen'])) === '') {
+            $h[] = $temp;
+        } else {
+            $h[] = str_replace($softHyphen, '&shy;', $temp);
+            $temp = str_replace($softHyphen, '', $temp);
+        }
         $ancestors[$l[$i] - 1] = XH_uenc($temp, $search, $replace);
         $ancestors = array_slice($ancestors, 0, $l[$i]);
         $url = implode($cf['uri']['seperator'], $ancestors);

--- a/cmsimple/languages/de.php
+++ b/cmsimple/languages/de.php
@@ -127,6 +127,7 @@ $tx['help']['site_compat']="Benötigt die Website Funktionen, die in CMSimple_XH
 $tx['help']['title_format']="Das Format des Seitentitels (&lt;title&gt;) wie er normalerweise oben in den Seitenreitern des Browsers angezeigt wird.";
 $tx['help']['uri_seperator']="Das Zeichen, das die Namen von Seiten und Unterseiten in der URL trennt.";
 $tx['help']['uri_word_separator']="Das Zeichen, das Wörter in der URL trennt.";
+$tx['help']['uri_soft_hyphen']="Eine Zeichenkette, die im Seitennamen als bedingter Trennstrich verwendet, aber in der URL ausgelassen wird.";
 $tx['help']['uri_length']="Die URLs der Seiten werden ab dieser Länge abgeschnitten. Das könnte sich in einer zukünftigen Version ändern, so dass es das Beste ist, kürzere Seitenüberschriften zu verwenden (z.B. durch die Verwendung von Seite&rarr;Andere Seitenüberschrift).";
 
 $tx['help']['folders_content']="Der Ordner, in dem die Inhalte gespeichert werden (content.htm etc.)";

--- a/cmsimple/languages/en.php
+++ b/cmsimple/languages/en.php
@@ -126,6 +126,7 @@ $tx['help']['site_compat']="Whether the website needs functions that have been r
 $tx['help']['title_format']="The way the title of a page of your site (&lt;title&gt;) is shown in the tab of your browser.";
 $tx['help']['uri_seperator']="The character which separates names of pages and sub pages in the URL.";
 $tx['help']['uri_word_separator']="The character which separates words in the URL.";
+$tx['help']['uri_soft_hyphen']="A character string that is used as soft hyphen in the page heading, but is omitted from the URL.";
 $tx['help']['uri_length']="The URLs of the pages will be truncated at this length. This might change in a future release, so it's best to use shorter page headings (e.g. by using Page&rarr;Alternative heading).";
 
 $tx['help']['folders_content']="The folder where the contents are stored (content.htm etc.)";


### PR DESCRIPTION
While it is already possible to include soft hyphens in page headings
by manually inserting the SOFT HYPHEN (U+00AD) character, these are
usually not displayed when editing page headings, although soft hyphens
appear to be particularly useful for page headings.

Thus, we allow to configure an arbitrary string to stand in for a soft
hyphen, which is, however, omitted from the page URL.  If that config
option is empty (the default), everything stays as it was before.