### PR TITLE
TinyMCE's CodeMirror source view should use the configured theme

### DIFF
--- a/plugins/tinymce4/init.php
+++ b/plugins/tinymce4/init.php
@@ -238,7 +238,9 @@ function tinymce4_config($config, $selector)
     /*
      * use the codemirror theme configured for Codeeditor_XH if available
      */
-    $temp = str_replace('%CODEMIRROR_THEME%',$plugin_cf['codeeditor']['theme'],$temp);
+    if (isset($plugin_cf['codeeditor']['theme'])) {
+        $temp = str_replace('%CODEMIRROR_THEME%',$plugin_cf['codeeditor']['theme'],$temp);
+    }
 
     $elementFormat = $cf['xhtml']['endtags'] == 'true' ? 'xhtml' : 'html';
     $temp = str_replace('%ELEMENT_FORMAT%', $elementFormat, $temp);

--- a/plugins/tinymce4/init.php
+++ b/plugins/tinymce4/init.php
@@ -235,6 +235,11 @@ function tinymce4_config($config, $selector)
         '%CMSIMPLE_ROOT%', CMSIMPLE_ROOT, $temp
     );
 
+    /*
+     * use the codemirror theme configured for Codeeditor_XH if available
+     */
+    $temp = str_replace('%CODEMIRROR_THEME%',$plugin_cf['codeeditor']['theme'],$temp);
+
     $elementFormat = $cf['xhtml']['endtags'] == 'true' ? 'xhtml' : 'html';
     $temp = str_replace('%ELEMENT_FORMAT%', $elementFormat, $temp);
     

--- a/plugins/tinymce4/inits/init_fontawesome-codemirror.js
+++ b/plugins/tinymce4/inits/init_fontawesome-codemirror.js
@@ -37,7 +37,7 @@
     height: 800,
     fullscreen: false,
     config:{
-      theme: 'zenburn'
+      theme: '%CODEMIRROR_THEME%'
     }
   }
 }

--- a/plugins/tinymce4/tinymce/plugins/codemirror/source.html
+++ b/plugins/tinymce4/tinymce/plugins/codemirror/source.html
@@ -59,7 +59,7 @@ function inArray(key, arr)
 			'codemirror-combined.css']
 	};
   
-  if (typeof userSettings.config !== 'undefined' && typeof userSettings.config.theme !== 'undefined')   
+  if (typeof userSettings.config !== 'undefined' && typeof userSettings.config.theme !== 'undefined' && userSettings.config.theme !== "default")
     CMsettings.cssFiles.push('theme/' + userSettings.config.theme + '.css');
 
   // Merge config

--- a/plugins/tinymce5/classes/Editor.php
+++ b/plugins/tinymce5/classes/Editor.php
@@ -146,6 +146,11 @@ class Editor
         $parsedconfig = str_replace('%STYLESHEET%',$pth['folder']['template'] . 'stylesheet.css',$parsedconfig);
         $parsedconfig = str_replace('%CMSIMPLE_ROOT%',CMSIMPLE_ROOT,$parsedconfig);
         
+        /*
+         * Use the codemirror theme configured for Codeeditor_XH if available.
+         */
+        $parsedconfig = str_replace('%CODEMIRROR_THEME%',$plugin_cf['codeeditor']['theme'],$parsedconfig);
+        
         /* 
          * Enable the file_picker_callback in Admin mode only (functions/callbacks not possible in JSON)
         */

--- a/plugins/tinymce5/classes/Editor.php
+++ b/plugins/tinymce5/classes/Editor.php
@@ -149,7 +149,9 @@ class Editor
         /*
          * Use the codemirror theme configured for Codeeditor_XH if available.
          */
-        $parsedconfig = str_replace('%CODEMIRROR_THEME%',$plugin_cf['codeeditor']['theme'],$parsedconfig);
+        if (isset($plugin_cf['codeeditor']['theme'])) {
+            $parsedconfig = str_replace('%CODEMIRROR_THEME%',$plugin_cf['codeeditor']['theme'],$parsedconfig);
+        }
         
         /* 
          * Enable the file_picker_callback in Admin mode only (functions/callbacks not possible in JSON)

--- a/plugins/tinymce5/inits/init_dropdown-codemirror.json
+++ b/plugins/tinymce5/inits/init_dropdown-codemirror.json
@@ -37,7 +37,7 @@
   "images_reuse_filename": false,
   "codemirror":{
     "config": {
-      "theme": "zenburn"
+      "theme": "%CODEMIRROR_THEME%"
     }
   }
 }

--- a/plugins/tinymce5/tinymce/plugins/codemirror/source.html
+++ b/plugins/tinymce5/tinymce/plugins/codemirror/source.html
@@ -59,7 +59,7 @@ function inArray(key, arr)
 			'codemirror-combined.css']
 	};
   
-  if (typeof userSettings.config !== 'undefined' && typeof userSettings.config.theme !== 'undefined') 
+  if (typeof userSettings.config !== 'undefined' && typeof userSettings.config.theme !== 'undefined'  && userSettings.config.theme !== "default")
     CMsettings.cssFiles.push('theme/' + userSettings.config.theme + '.css');
 
   // Merge config


### PR DESCRIPTION
TinyMCE's CodeMirror plugin currently relies on Codeeditor_XH.  Thus,
it should use the theme configured for Codeeditor_XH.

See <https://cmsimpleforum.com/viewtopic.php?f=12&t=4052&start=30#p80989>ff.