### PR TITLE
Remove empty selected from query string

### DIFF
--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -781,7 +781,7 @@ if (sv('QUERY_STRING') != '') {
     if (!strpos($j[0], '=')) {
         $su = $j[0];
     }
-    if ($su == '' && $selected != '') {
+    if ($su == '') {
         if (isset($_GET['selected'])) {
             header('Location: ' . XH_redirectSelectedUrl(), true, 301);
             exit;

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2638,11 +2638,15 @@ function XH_redirectSelectedUrl()
 {
     global $selected;
 
-    $queryString = ltrim(preg_replace('/&?selected=[^&]+/', '', $_SERVER['QUERY_STRING']), '&');
+    $queryString = ltrim(preg_replace('/&?selected=[^&]*/', '', $_SERVER['QUERY_STRING']), '&');
     if ($queryString) {
         $queryString = "$selected&$queryString";
     } else {
         $queryString = $selected;
     }
-    return CMSIMPLE_URL . "?$queryString";
+    $url = CMSIMPLE_URL;
+    if ($queryString !== "") {
+        $url .= "?$queryString";
+    }
+    return $url;
 }

--- a/content/content.htm
+++ b/content/content.htm
@@ -37,6 +37,7 @@ $page_data[]=array(
 );
 ?>
 <h1>Start</h1>
+<div>{{{testit()}}}</div>
 <p class="xh_success">Congratulations on the successful installation of <strong>CMSimple_XH</strong>.</p>
 <p>If this text is displayed, you have done everything right. You should now make some basic settings, then you can immediately start with your own homepage.</p>
 <h2>Login</h2>


### PR DESCRIPTION
Typically, GET forms that should be submitted to the same page use a
`<input type="hidden" name="selected" value="$su">`.  Such GET requests
(`?selected=page`) are then permanently redirected to the respective
page.  However, that fails on the first page where `$su` is empty, and
results in `?selected=`.

Instead, we need to redirect even if `$selected` is empty, and to make
sure that we remove the query parameter in that case, and also not to
have a trailing `?`.