### PR TITLE
Fix #555 (empty lines before page heading the content)

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -791,7 +791,7 @@ function XH_readContents($language = null)
     foreach ($c as $i => $j) {
         if (preg_match('/<\?php(.*?)\?>/is', $j, $m)) {
             eval($m[1]);
-            $c[$i] = preg_replace('/<\?php(.*?)\?>/is', '', $j);
+            $c[$i] = preg_replace('/\R*<\?php(.*?)\?>\R*/is', '', $j);
             $hasPageData = true;
         } else {
             $page_data[] = array();

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -419,7 +419,7 @@ function content()
         }
         $o .= preg_replace('/#CMSimple (.*?)#/is', '', $c[$s]);
     }
-    return  preg_replace('/<!--XH_ml[1-9]:.*?-->/is', '', $o);
+    return  preg_replace('/<!--XH_ml[1-9]:.*?-->\R*/is', '', $o);
 }
 
 

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -419,7 +419,7 @@ function content()
         }
         $o .= preg_replace('/#CMSimple (.*?)#/is', '', $c[$s]);
     }
-    return  preg_replace('/<!--XH_ml[1-9]:.*?-->\R*/is', '', $o);
+    return  preg_replace('/<!--XH_ml[1-9]:.*?-->/is', '', $o);
 }
 
 


### PR DESCRIPTION
~~This is basically @olape-git's suggestion from the CMSimple_XH forum[1], but using a shortcut, and not relying on line breaks.~~

~~[1] <https://cmsimpleforum.com/viewtopic.php?f=16&t=18315&start=60#p83033>~~

---

Mir ist leider nicht wirklich klar, worum es hier genau geht. [@TN03 talks about non-breaking spaces](https://github.com/cmsimple-xh/cmsimple-xh/issues/555#issuecomment-1094080788), but the issue title and the linked discussion in the forum is about line breaks. Das sind definitiv verschiedene Dinge. Geht es Holger um [diese Zeile](https://github.com/cmsimple-xh/cmsimple-xh/blob/4a7722318d2708db4b455bec00cd06fef8913ce4/cmsimple/functions.php#L759)?

Und mir ist auch nicht wirklich klar, ob diese eine Stelle genügt (`<!--XH_ml[1-9]` findet man an viel zu vielen Stellen im Quellcode), und ob sie überhaupt sinnvoll ist. Ich frage mich, ob nicht der korrekte Fix ist, die Leerzeilen beim [Entfernen des Page-Data-Scripts](https://github.com/cmsimple-xh/cmsimple-xh/blob/4a7722318d2708db4b455bec00cd06fef8913ce4/cmsimple/functions.php#L794) ebenfalls zu entfernen, also:
````diff
 cmsimple/functions.php | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/cmsimple/functions.php b/cmsimple/functions.php
index 23c4f5da..4cf2737b 100644
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -791,7 +791,7 @@ function XH_readContents($language = null)
     foreach ($c as $i => $j) {
         if (preg_match('/<\?php(.*?)\?>/is', $j, $m)) {
             eval($m[1]);
-            $c[$i] = preg_replace('/<\?php(.*?)\?>/is', '', $j);
+            $c[$i] = preg_replace('/\R*<\?php(.*?)\?>\R*/is', '', $j);
             $hasPageData = true;
         } else {
             $page_data[] = array();
````