### PR TITLE
Plugincalls returning null|void emit deprecation notices

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -240,7 +240,7 @@ function XH_evaluateSinglePluginCall($___expression)
     return preg_replace_callback(
         '/#(CMSimple .*?)#/is',
         'XH_escapeCMSimpleScripting',
-        eval('return ' . $___expression . ';')
+        (string) eval('return ' . $___expression . ';')
     );
 }
 


### PR DESCRIPTION
The return value of plugin calls is passed to `preg_replace_callback()` unmodified, and automatically coerced to a string, because that is what `$subject` expects.  This works fine for all scalar values, and also for `null` (or even if the function does not return a value at all) prior to PHP 8.1.0.  However, as of that PHP version, coercing `null|void` to `string` is deprecated.  We fix that by casting to `string` explicitly.

---

Mir ist das durch Zufall aufgefallen, weil ich auf einer Seite `{{{shead(404)}}}` ausprobiert hatte. `shead()` gibt nichts zurück, was bei PHP eben `null` zurückliefert. Und dass `null` an einen String-Parameter einer eingebauten Funktion übergeben wird, ist eben seit PHP 8.1.0 missbilligt. Ich sehe keine Probleme mit der in diesem PR vorgeschlagenen Lösung, aber man könnte natürlich genauso gut argumentieren, dass Pluginaufrufe eben einen akzeptablen Wert zurückliefern müssen (also ein [skalarer Wert](https://www.php.net/manual/en/function.is-scalar.php)). Ich vermute aber, dass manche User `void` Funktionen aufrufen, oder dass ein Plugin auch mal `null` zurückgibt. Sprich: diese Lösung würde größtmögliche Kompatibilität bieten, aber es eben weiterhin erlauben hier etwas schlampig zu sein. Wir könnten also noch weiter ausholen, und den Rückgabewert zunächst prüfen, um dem Anwender zu signalisieren, dass da etwas nicht richtig ist. Ist aber vielleicht auch einfach zu pingelig.

Was denkt ihr?