### PR TITLE
More options for form fields in metaconfig.php

### DIFF
--- a/cmsimple/classes/ArrayFileEdit.php
+++ b/cmsimple/classes/ArrayFileEdit.php
@@ -176,6 +176,72 @@ abstract class ArrayFileEdit extends FileEdit
                 }
                 $o .= '</datalist>';
                 return $o;
+            case 'password':
+                if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}
+                $o = '<input type="password" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val'])
+                    . (!empty($opt['vals'][0]) ? '" minlength="' . XH_hsc($opt['vals'][0]) : '')
+                    . '" class="xh_setting">';
+                return $o;
+            case 'email':
+                $o = '<input type="email" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val'])
+                    . '" class="xh_setting">';
+                return $o;
+            case 'number':
+                if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}
+                $o = '<input type="number" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val'])
+                    . (!empty($opt['vals'][0]) ? '" min="' . XH_hsc($opt['vals'][0]) : '')
+                    . (!empty($opt['vals'][1]) ? '" max="' . XH_hsc($opt['vals'][1]) : '')
+                    . (!empty($opt['vals'][2]) ? '" step="' . XH_hsc($opt['vals'][2]) : '')
+                    . '" class="xh_setting">';
+                return $o;
+            case 'range':
+                if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}
+                $o = '<input type="range" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val'])
+                    . (!empty($opt['vals'][0]) ? '" min="' . XH_hsc($opt['vals'][0]) : '')
+                    . (!empty($opt['vals'][1]) ? '" max="' . XH_hsc($opt['vals'][1]) : '')
+                    . (!empty($opt['vals'][2]) ? '" step="' . XH_hsc($opt['vals'][2]) : '')
+                    . '" class="xh_setting">';
+                return $o;
+            case 'color':
+                if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}
+                $o = '<input type="color" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val']) . '" class="xh_setting"';
+                if ($opt['vals'][0]) {
+                    $o .= ' list="' . $iname . '_DATA">';
+                    $o .= '<datalist id="' . $iname . '_DATA">';
+                    foreach ($opt['vals'] as $val) {
+                        $label = ($val == '')
+                            ? ' label="' . $tx['label']['empty'] . '"'
+                            : '';
+                        $o .= '<option' . $label . ' value="' . XH_hsc($val) . '">';
+                    }
+                    $o .= '</datalist>';
+                } else {
+                    $o .= '>';
+                }
+                return $o;
+            case 'date':
+                if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}
+                $o = '<input type="date" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val'])
+                    . (!empty($opt['vals'][0]) ? '" min="' . XH_hsc($opt['vals'][0]) : '')
+                    . (!empty($opt['vals'][1]) ? '" max="' . XH_hsc($opt['vals'][1]) : '')
+                    . (!empty($opt['vals'][2]) ? '" step="' . XH_hsc($opt['vals'][2]) : '')
+                    . '" class="xh_setting">';
+                return $o;
+            case 'time':
+                if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}
+                $o = '<input type="time" name="' . $iname . '" value="'
+                    . XH_hsc($opt['val'])
+                    . (!empty($opt['vals'][0]) ? '" min="' . XH_hsc($opt['vals'][0]) : '')
+                    . (!empty($opt['vals'][1]) ? '" max="' . XH_hsc($opt['vals'][1]) : '')
+                    . (!empty($opt['vals'][2]) ? '" step="' . XH_hsc($opt['vals'][2]) : '')
+                    . '" class="xh_setting">';
+                return $o;
             case 'hidden':
             case 'random':
                 return '<input type="hidden" name="' . $iname . '" value="'
@@ -332,6 +398,12 @@ abstract class ArrayFileEdit extends FileEdit
         switch ($typeTag) {
             case 'enum':
             case 'xenum':
+            case 'password':
+            case 'number':
+            case 'range':
+            case 'color':
+            case 'date':
+            case 'time':
                 $vals = explode(',', substr($type, strlen($typeTag) + 1));
                 $type = $typeTag;
                 break;

--- a/cmsimple/classes/ArrayFileEdit.php
+++ b/cmsimple/classes/ArrayFileEdit.php
@@ -204,7 +204,10 @@ abstract class ArrayFileEdit extends FileEdit
                     . (!empty($opt['vals'][0]) ? '" min="' . XH_hsc($opt['vals'][0]) : '')
                     . (!empty($opt['vals'][1]) ? '" max="' . XH_hsc($opt['vals'][1]) : '')
                     . (!empty($opt['vals'][2]) ? '" step="' . XH_hsc($opt['vals'][2]) : '')
-                    . '" class="xh_setting">';
+                    . '" class="xh_setting" oninput="' . $iname . '_num.value = this.value">';
+                $o .= '<output id="' . $iname . '_num">'
+                    . (XH_hsc($opt['val']) ? XH_hsc($opt['val']) : 'n.a.')
+                    . '</output>';
                 return $o;
             case 'color':
                 if ($opt['vals']) {$opt['vals'] = array_map('trim', $opt['vals']);}


### PR DESCRIPTION
https://github.com/cmsimple-xh/cmsimple-xh/issues/396

https://github.com/cmsimple-xh/cmsimple-xh/issues/269

possibilities so far:

for textarea - "text"
for checkbox - "bool"
for dropdown - "enum:1,2,3"
for datalist - "xenum:4,5,6"
fur random - "random"
for hidden - "hidden"
for text - "string"

now additionally:

for password - "password"
or password with minimum length - "password:8"

for email - "email"

for number - "number"
for number with min - "number:-5"
for number with max - "number:,6"
for number with step - "number:,,0.1"
for number with min, max and step - "number:-5,6,0.5"

for range - "range"
for range with min, max and step - "range:50,80,10"
and so on,see at number

for colorpicker - "color"
for colorpciker with user-defined colors - "color:#ff0000,#00ff00,#0000ff";
and so on

for date - "date"
for date with min, max and step - "date:2024-01-01,2024-07-31,2"
and so on, see at number

for time - "time"
for time - with min, max and step - "time:08:00,16:30,900";
and so on, see at number