### PR TITLE
printlink for newsbox

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -269,18 +269,22 @@ function evaluate_scripting($text, $compat = true)
  *
  * @return string|false
  */
-function newsbox($heading)
+function newsbox($heading, $print = false)
 {
-    global $c, $cl, $h, $edit;
+    global $c, $cl, $h, $u, $edit;
 
     for ($i = 0; $i < $cl; $i++) {
         if ($h[$i] == $heading) {
             $pattern = '/.*?<!--XH_ml[1-9]:.*?-->/isu';
             $body = preg_replace($pattern, "", $c[$i]);
             $pattern = '/#CMSimple (.*?)#/is';
-            return XH_ADM && $edit
-                ? $body
-                : preg_replace($pattern, '', evaluate_scripting($body, false));
+            $boxContent = (XH_ADM && $edit
+                            ? $body
+                            :preg_replace($pattern, '', evaluate_scripting($body, false)));
+            if ($print && $print == 'printlink') {
+                $boxContent .= printlink($u[$i]);
+            }
+            return $boxContent;
         }
     }
     return false;

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -262,12 +262,14 @@ function sitemaplink()
  *
  * @return string HTML
  */
-function printlink()
+function printlink($url = false)
 {
     global $tx;
 
-    return '<a href="' . XH_printUrl() . '" rel="nofollow">'
-        . $tx['menu']['print'] . '</a>';
+        return '<a class="xh_printlink" href="'
+              . ($url ? XH_printUrl($url) : XH_printUrl())
+              . '" rel="nofollow">'
+              . $tx['menu']['print'] . '</a>';
 }
 
 /**
@@ -277,12 +279,14 @@ function printlink()
  *
  * @since 1.6
  */
-function XH_printUrl()
+function XH_printUrl($url = false)
 {
     global $f, $search, $file, $sn;
 
     $t = '&print';
-    if ($f == 'search') {
+    if ($url) {
+        $t = $url . $t;
+    } elseif ($f == 'search') {
         $t .= '&function=search&search=' . urlencode($search);
     } elseif ($f == 'file') {
         $t .= '&file=' . $file;

--- a/templates/fhs-simple-2019/template.htm
+++ b/templates/fhs-simple-2019/template.htm
@@ -79,7 +79,7 @@ if($s >= 0) {
 <?=toc(2,9);?></nav>
 <div id="newsboxes">
 <section class="news">
-<div class="newsin"><?=newsbox('News01');?></div>
+<div class="newsin"><?=newsbox('News01', 'printlink');?></div>
 </section>
 <section class="news">
 <div class="newsin"><?=newsbox('News02');?></div>
@@ -91,7 +91,7 @@ if($s >= 0) {
 <div class="submenDiv"><?=submenu('<span>%s</span>');?></div>
 <aside id="newsboxes2" class="row">
 <section class="news">
-<?=newsbox('News01');?>
+<?=newsbox('News01', 'printlink');?>
 </section>
 <section class="news">
 <?=newsbox('News02');?>


### PR DESCRIPTION
It is therefore possible to include a second parameter when calling the newsbox() function. Instead of <?=newsbox('News01');?> then <?=newsbox('News01', 'printlink');?>. This will display the link to the print preview in the newsbox (only for the content of this newsbox).

It is also possible to add a url to the printlink() function. For example, printlink('Test/Test page'). This could be useful for content in Expandcontract_XH, for example.

https://github.com/cmsimple-xh/cmsimple-xh/issues/24