### PR TITLE
Check external links either with cURL or get_headers()

### DIFF
--- a/cmsimple/classes/LinkChecker.php
+++ b/cmsimple/classes/LinkChecker.php
@@ -308,7 +308,7 @@ class LinkChecker
             }
         }
         // alternative to cURL
-        if (function_exists('get_headers')) {
+        elseif (function_exists('get_headers')) {
             $context = stream_context_create(
                 array(
                     'http' => array(


### PR DESCRIPTION
It doesn't seem to make much sense to try *again* with `get_headers()`, after a cURL request failed; the `get_headers()` request is likely to fail as well.

---

Maybe we're even better off to require cURL for checking external links (and just report an unknown status in case cURL is not available); this would simplify troubleshooting.