### PR TITLE
Resolve unused variable warnings of PHPMD

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -1139,8 +1139,6 @@ function XH_restore($filename)
  */
 function XH_delete($filename)
 {
-    global $e;
-
     if (!unlink($filename)) {
         e('cntdelete', 'content', $filename);
         return;

--- a/cmsimple/classes/ChangePassword.php
+++ b/cmsimple/classes/ChangePassword.php
@@ -152,7 +152,7 @@ class ChangePassword
      */
     public function saveAction()
     {
-        global $o;
+        global $o, $pth;
 
         $this->csrfProtector->check();
         if ($hash = $this->validate($error)) {


### PR DESCRIPTION
While `$e` is actually not required in `XH_delete()` (so the global declaration is merely a no-op), `$pth` is actually used in `ChangePassword::saveAction()`, so we need to declare it as global.