### PR TITLE
Prepare to re-enable ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/checkout@v3
       - name: composer install
         run: composer install
-      - name: phing sniff
-        run: PATH=vendor/bin:$PATH phing sniff
+#      - name: phing sniff
+#        run: PATH=vendor/bin:$PATH phing sniff
       - name: phing phan
         run: PATH=vendor/bin:$PATH phing phan
       - name: phing mess
         run: PATH=vendor/bin:$PATH phing mess
-      - name: phing unit-test
-        run: PATH=vendor/bin:$PATH phing unit-tests
+#      - name: phing unit-test
+#        run: PATH=vendor/bin:$PATH phing unit-tests


### PR DESCRIPTION
While `phing sniff` and `phing unit-tests` currently fail with an awful lot of errors, `phing phan` apparently shows no issues, and `phing mess` should be good after applying #649.

---

See https://github.com/cmb69/cmsimple-xh/actions/runs/13653682795/job/38167790798 for the current state.

Regarding the coding standard: in my opinion, following *some* coding standard is a generally a good idea, especially when there are multiple contributors to a project. Of course, any particular coding standard is debatable, and so is [PSR-2](https://www.php-fig.org/psr/psr-2/), as well as its successor [PSR-12](https://www.php-fig.org/psr/psr-12/), as well as its successor [PER CS 2.0](https://www.php-fig.org/per/coding-style/). I'm fine with switching to something else, or to make some deliberate alterations. It's also somewhat okayish for me to drop any CS altogether, but in that case we should remove the remains of using PHPCodeSniffer, and likely need to adapt some documentation.

Regarding the unit-tests: a lot of these are hackish, require ext/uopz which is not yet up-to-date for PHP 8.4, and are generally hard to maintain. Still, it seems to me we should have automated tests. Otherwise we need to rely solely on manual testing, and likely miss some issues, especially wrt new PHP versions. If desired, I can work on the unit-tests (and generally updating the ci workflow).