### PR TITLE
Move executable statement out of adminfuncs.php

### DIFF
--- a/cmsimple/adminfuncs.php
+++ b/cmsimple/adminfuncs.php
@@ -43,7 +43,6 @@ function XH_checkDefaultPW()
     }
     return false;
 }
-$e .= XH_checkDefaultPW();
 
 /**
  * Returns the readable version of a plugin.

--- a/cmsimple/cms.php
+++ b/cmsimple/cms.php
@@ -911,6 +911,7 @@ define('XH_ADM', $adm);
 
 if (XH_ADM) {
     include_once $pth['folder']['cmsimple'] . 'adminfuncs.php';
+    $e .= XH_checkDefaultPW();
     if (isset($_GET['xh_keep_alive'])) {
         $_XH_controller->handleKeepAlive();
     }


### PR DESCRIPTION
The whole point of adminfuncs.php is to contain functions only (and maybe other declarations), so that it can be included by clients without actually executing any code.

Thus we move the statement to cms.php right after adminfuncs.php has been included there, having the same effect as if it was contained in adminfuncs.php.

---

I've just noticed that while having a look at a [CI run of Twocents_XH](https://github.com/cmb69/twocents_xh/actions/runs/14736180159/job/41362723222#step:12:13). It's not a big problem right now, but I'd like to keep statements and declarations in separate files (some exceptions are okay for me).