### PR TITLE
Rehash password if necessary

### DIFF
--- a/cmsimple/classes/ChangePassword.php
+++ b/cmsimple/classes/ChangePassword.php
@@ -197,7 +197,7 @@ class ChangePassword
                 } elseif ($this->passwordNew != $this->passwordConfirmation) {
                     $error = $this->lang['password']['mismatch'];
                 } else {
-                    $result = password_hash($this->passwordNew, PASSWORD_BCRYPT);
+                    $result = password_hash($this->passwordNew, PASSWORD_BCRYPT, ['cost' => 12]);
                 }
             }
         } else {

--- a/cmsimple/classes/Controller.php
+++ b/cmsimple/classes/Controller.php
@@ -183,9 +183,12 @@ class Controller
                 $f = 'xh_login_pw_expired';
                 XH_logMessage('warning', 'XH', 'login', 'login password expired');
             } else {
-                if ($keycut !== 'test' && password_needs_rehash($cf['security']['password'], PASSWORD_BCRYPT)) {
+                if (
+                    $keycut !== 'test'
+                    && password_needs_rehash($cf['security']['password'], PASSWORD_BCRYPT, ['cost' => 12])
+                ) {
                     $_SESSION['xh_default_password'] = false;
-                    $cf['security']['password'] = password_hash($keycut, PASSWORD_BCRYPT);
+                    $cf['security']['password'] = password_hash($keycut, PASSWORD_BCRYPT, ['cost' => 12]);
                     $this->saveConfig($pth['file']['config'], $cf);
                 }
                 setcookie('status', 'adm', 0, CMSIMPLE_ROOT);

--- a/cmsimple/classes/Controller.php
+++ b/cmsimple/classes/Controller.php
@@ -184,6 +184,7 @@ class Controller
                 XH_logMessage('warning', 'XH', 'login', 'login password expired');
             } else {
                 if ($keycut !== 'test' && password_needs_rehash($cf['security']['password'], PASSWORD_BCRYPT)) {
+                    $_SESSION['xh_default_password'] = false;
                     $cf['security']['password'] = password_hash($keycut, PASSWORD_BCRYPT);
                     $this->saveConfig($pth['file']['config'], $cf);
                 }

--- a/cmsimple/classes/PasswordForgotten.php
+++ b/cmsimple/classes/PasswordForgotten.php
@@ -140,7 +140,7 @@ class PasswordForgotten
         global $pth, $cf, $tx, $e;
 
         $password = bin2hex(random_bytes(8));
-        $hash = password_hash($password, PASSWORD_BCRYPT);
+        $hash = password_hash($password, PASSWORD_BCRYPT, ['cost' => 12]);
         if (($hash !== false) && ($password != '')) {
             $to = $cf['security']['email'];
             $message = $tx['password_forgotten']['email2_text'] . ' ' . $password;

--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -1,17 +1,17 @@
 <?php
 
-$cf['security']['password']="\$2y\$10\$TtMCJlxEv6D27BngvfdNrewGqIx2R0aPCHORruqpe63LQpz7.E9Gq";
-$cf['password']['min_length']="8";
-$cf['password']['max_remaining_time']="300";
+$cf['security']['password']="\$2y\$12\$9NXtNK1JPVQcDIpHJ/l.8e0s49uNzAMFkTAR1itoj4ytThn5EKSJC";
 $cf['security']['secret']="b41bd1913a2a5412f41cabcf";
 $cf['security']['email']="";
 $cf['security']['frame_options']="";
+$cf['password']['min_length']="8";
+$cf['password']['max_remaining_time']="300";
 $cf['site']['template']="fhs-simple-2019";
 $cf['site']['timezone']="";
 $cf['site']['compat']="true";
 $cf['language']['default']="en";
-$cf['languagemenu']['external']="";
 $cf['language']['2nd_lang_names']="cs=Čeština;da=Dansk;de=Deutsch;en=English;es=Español;fi=Suomi;fr=Français;el=Ελληνικά;hu=Magyar;it=Italiano;nl=Nederlands;no=Norsk;pl=Polski;ru=Русский;sv=Svensk;sk=Slovenčina";
+$cf['languagemenu']['external']="";
 $cf['mailform']['email']="";
 $cf['mailform']['captcha']="true";
 $cf['mailform']['lf_only']="";
@@ -63,3 +63,5 @@ $cf['validate']['mailto']="true";
 $cf['validate']['tel']="true";
 $cf['validate']['redir']="0";
 $cf['debug']['log']="";
+
+?>

--- a/cmsimple/config.php
+++ b/cmsimple/config.php
@@ -1,17 +1,17 @@
 <?php
 
-$cf['security']['password']="\$2y\$12\$9NXtNK1JPVQcDIpHJ/l.8e0s49uNzAMFkTAR1itoj4ytThn5EKSJC";
+$cf['security']['password']="\$2y\$10\$TtMCJlxEv6D27BngvfdNrewGqIx2R0aPCHORruqpe63LQpz7.E9Gq";
+$cf['password']['min_length']="8";
+$cf['password']['max_remaining_time']="300";
 $cf['security']['secret']="b41bd1913a2a5412f41cabcf";
 $cf['security']['email']="";
 $cf['security']['frame_options']="";
-$cf['password']['min_length']="8";
-$cf['password']['max_remaining_time']="300";
 $cf['site']['template']="fhs-simple-2019";
 $cf['site']['timezone']="";
 $cf['site']['compat']="true";
 $cf['language']['default']="en";
-$cf['language']['2nd_lang_names']="cs=Čeština;da=Dansk;de=Deutsch;en=English;es=Español;fi=Suomi;fr=Français;el=Ελληνικά;hu=Magyar;it=Italiano;nl=Nederlands;no=Norsk;pl=Polski;ru=Русский;sv=Svensk;sk=Slovenčina";
 $cf['languagemenu']['external']="";
+$cf['language']['2nd_lang_names']="cs=Čeština;da=Dansk;de=Deutsch;en=English;es=Español;fi=Suomi;fr=Français;el=Ελληνικά;hu=Magyar;it=Italiano;nl=Nederlands;no=Norsk;pl=Polski;ru=Русский;sv=Svensk;sk=Slovenčina";
 $cf['mailform']['email']="";
 $cf['mailform']['captcha']="true";
 $cf['mailform']['lf_only']="";
@@ -63,5 +63,3 @@ $cf['validate']['mailto']="true";
 $cf['validate']['tel']="true";
 $cf['validate']['redir']="0";
 $cf['debug']['log']="";
-
-?>

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1445,7 +1445,7 @@ function XH_readFile($filename)
 function XH_writeFile($filename, $contents, $pwChange = false)
 {
     $res = false;
-    if ($_SESSION['xh_default_password'] && !$pwChange) {
+    if (array_key_exists('xh_default_password', $_SESSION) && $_SESSION['xh_default_password'] && !$pwChange) {
         return $res;
     }
     $stream = fopen($filename, 'cb');
@@ -2267,7 +2267,7 @@ function XH_onShutdown()
 {
     global $tx;
 
-    if (!XH_ADM && isset($_SESSION['xh_password'])) {
+    if (defined("XH_ADM") && !XH_ADM && isset($_SESSION['xh_password'])) {
         unset($_SESSION['xh_password']);
     }
 


### PR DESCRIPTION
We're using the default parameters of `PASSWORD_BCRYPT`, and especially the `cost` parameter increased for more recent PHP versions what is a consequence of ever increasing computing power.  However, if a password has been hashed with an older PHP version, or a user reuses a hash that has been created by an old CMSimple_XH version, the `cost` factor might be as low as `10` or even only `8`, while PHP 8.4 uses `12` by default.

To cater to this, we check whether the password needs to be re-hashed on successful login with a non-default password, and if so, re-hash the password.  To be able to actually store the new hash in config.php, we move the respective method from `ChangePassword` to the `Controller` so we can re-use the non trivial logic.

---

A next step could be to use a fixed `cost` factor in the first place. This would have the advantage that users running older PHP versions would still benefit from a more contemporary hashing cost. The drawback: if we forget to increase the fixed `cost` factor in the future, we might actually weaken security a bit. To my knowledge, there is no way to detect the default `cost` factor, so we could apply the maximum.

A general improvement would be to provide some wrapper over the `password_*` functions. As is we're using `PASSWORD_BCRYPT` in three distinct places, so we might miss some if we ever change that.