### PR TITLE
Fix #654: Redirection due to selected is broken as of PHP 8.0.0

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -2267,7 +2267,7 @@ function XH_onShutdown()
 {
     global $tx;
 
-    if (!XH_ADM && isset($_SESSION['xh_password'])) {
+    if (defined('XH_ADM') && !XH_ADM && isset($_SESSION['xh_password'])) {
         unset($_SESSION['xh_password']);
     }
 


### PR DESCRIPTION
We make sure that `XH_ADM` is actually defined before we access it to avoid a fatal error in PHP 8, in case we exit early, before `XH_ADM` is actually defined.

We do not unset the password hash stored in the session in this case, since that would lead to unintentional logout.