### PR TITLE
Upgrade CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
         required: true
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -15,7 +15,7 @@ jobs:
           php-version: '8.1'
           tools: composer
       - name: Checkout CMSimple_XH
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install composer
         run: composer install
       - name: Build CMSimple_XH
@@ -23,7 +23,7 @@ jobs:
       - name: Unzip build
         run: unzip CMSimple_XH-${{github.event.inputs.version}}.zip -d artifacts
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CMSimple_XH-${{github.event.inputs.version}}
           path: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Check
 on: [push, pull_request]
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php_version: ['8.1', '8.0', '7.4', '7.3', '7.2']
@@ -15,7 +15,7 @@ jobs:
           ini-values: uopz.exit=1
           tools: composer
       - name: Checkout CMSimple_XH
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: composer install
         run: composer install
 #      - name: phing sniff


### PR DESCRIPTION
Ubuntu 20.04 images are in the process of being removed, so we switch to Ubuntu 22.04.

We also upgrade the GH checkout and upload-artifact actions to v4.

---

See https://github.com/cmb69/cmsimple-xh/actions/runs/14972023639 (I like green).