### PR TITLE
Test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Check
 on: [push, pull_request]
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php_version: ['8.1', '8.0', '7.4', '7.3', '7.2']
@@ -24,5 +24,5 @@ jobs:
         run: PATH=vendor/bin:$PATH phing phan
       - name: phing mess
         run: PATH=vendor/bin:$PATH phing mess
-#      - name: phing unit-test
-#        run: PATH=vendor/bin:$PATH phing unit-tests
+      - name: phing unit-test
+        run: PATH=vendor/bin:$PATH phing unit-tests

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1761,7 +1761,7 @@ function XH_helpIcon($tooltip)
  * Returns whether a file is a content backup by checking the filename.
  *
  * @param string $filename    A filename.
- * @param bool   $regularOnly Whether to check for regalur backup names only.
+ * @param string $regularOnly Whether to check for regalur backup names only.
  *
  * @return bool
  *

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -559,6 +559,7 @@ function languagemenu()
 /**
  * Provides a minimal template (in case template isn't found).
  *
+ * @param string $tplError
  * @return void
  *
  * @since 1.6.3

--- a/tests/unit/BackupTest.php
+++ b/tests/unit/BackupTest.php
@@ -58,16 +58,16 @@ class BackupTest extends TestCase
     public function dataForIsContentBackup()
     {
         return array(
-            array('20140503_192021_content.htm', true, true),
-            array('20140503_1920_content.htm', true, false),
-            array('20140503_192021_special.htm', true, false),
-            array('20140503_192021_special.html', true, false),
-            array('2013-07-11-01-02-03-content.htm', true, false),
-            array('20140503_192021_content.htm', false, true),
-            array('20140503_1920_content.htm', false, false),
-            array('20140503_192021_special.htm', false, true),
-            array('20140503_192021_special.html', false, false),
-            array('2013-07-11-01-02-03-content.htm', false, false)
+            array('20140503_192021_content.htm', 'content', true),
+            array('20140503_1920_content.htm', 'content', false),
+            array('20140503_192021_special.htm', 'content', false),
+            array('20140503_192021_special.html', 'content', false),
+            array('2013-07-11-01-02-03-content.htm', 'content', false),
+            array('20140503_192021_content.htm', '', true),
+            array('20140503_1920_content.htm', '', false),
+            array('20140503_192021_special.htm', '', true),
+            array('20140503_192021_special.html', '', false),
+            array('2013-07-11-01-02-03-content.htm', '', false)
         );
     }
 

--- a/tests/unit/ControllerLoginTest.php
+++ b/tests/unit/ControllerLoginTest.php
@@ -61,11 +61,12 @@ class ControllerLoginTest extends ControllerLogInOutTestCase
             'REMOTE_ADDR' => '127.0.0.1'
         );
         $pth = array(
-            'folder' => ['cmsimple' => './cmsimple/'],
+            'folder' => ['cmsimple' => './cmsimple/', 'downloads' => './userfiles/downloads'],
             'file' => ['log' => ''],
         );
         $this->passwordVerifyMock = $this->createFunctionMock('password_verify');
         $cf['security']['password'] = '$P$BHYRVbjeM5YAvnwX2AkXnyqjLhQAod1';
+        $cf['password']['max_remaining_time'] = '300';
         $this->eMock = $this->createFunctionMock('e');
         $this->logMessageMock = $this->createFunctionMock('XH_logMessage');
         $this->filePutContentsMock = $this->createFunctionMock('file_put_contents');

--- a/tests/unit/CoreTextFileEditTest.php
+++ b/tests/unit/CoreTextFileEditTest.php
@@ -127,6 +127,7 @@ class CoreTextFileEditTest extends TestCase
         );
         $exitSpy = $this->createFunctionMock('XH_exit');
         $exitSpy->expects($this->once());
+        $_SESSION = ['xh_default_password' => ''];
         $_POST = array('text' => '</html>');
         $this->subject->submit();
         $headerSpy->restore();

--- a/tests/unit/EmergencyTemplateTest.php
+++ b/tests/unit/EmergencyTemplateTest.php
@@ -34,7 +34,7 @@ class EmergencyTemplateTest extends TestCase
     protected function setUp(): void
     {
         $mockNames = array(
-            'header', 'head', 'onload', 'toc', 'content', 'loginlink', 'XH_exit'
+            'header', 'head', 'onload', 'toc', 'content', 'loginlink', 'XH_exit', 'languagemenu',
         );
         foreach ($mockNames as $mockName) {
             $this->mocks[$mockName] = $this->createFunctionMock($mockName);
@@ -61,7 +61,7 @@ class EmergencyTemplateTest extends TestCase
     {
         $this->mocks['header']->expects($this->atLeastOnce())
             ->willReturn('HTTP/1.0 503 Service Unavailable');
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -73,7 +73,7 @@ class EmergencyTemplateTest extends TestCase
     {
         $this->mocks['header']->expects($this->atLeastOnce())
             ->willReturn('Content-Type: text/html;charset=UTF-8');
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -84,7 +84,7 @@ class EmergencyTemplateTest extends TestCase
     public function testCallsHead()
     {
         $this->mocks['head']->expects($this->once());
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -95,7 +95,7 @@ class EmergencyTemplateTest extends TestCase
     public function testCallsOnload()
     {
         $this->mocks['onload']->expects($this->once());
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -106,7 +106,7 @@ class EmergencyTemplateTest extends TestCase
     public function testCallsToc()
     {
         $this->mocks['toc']->expects($this->once());
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -117,7 +117,7 @@ class EmergencyTemplateTest extends TestCase
     public function testCallsContent()
     {
         $this->mocks['content']->expects($this->once());
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -128,7 +128,7 @@ class EmergencyTemplateTest extends TestCase
     public function testCallsLoginlink()
     {
         $this->mocks['loginlink']->expects($this->once());
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 
     /**
@@ -139,6 +139,6 @@ class EmergencyTemplateTest extends TestCase
     public function testExitsScript()
     {
         $this->mocks['XH_exit']->expects($this->once());
-        XH_emergencyTemplate();
+        XH_emergencyTemplate('');
     }
 }

--- a/tests/unit/ErrorHandlerTest.php
+++ b/tests/unit/ErrorHandlerTest.php
@@ -30,6 +30,8 @@ class ErrorHandlerTest extends TestCase
 
     protected function setUp(): void
     {
+        global $cf;
+        $cf = ['debug' => ['log' => '']]; 
         $this->errorHandling = error_reporting();
         error_reporting(-1);
     }

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -238,6 +238,7 @@ class FunctionsTest extends TestCase
 
     public function testWriteFile()
     {
+        $_SESSION = ['xh_default_password' => ''];
         $filename = './tests/unit/data/temp';
         $expected = 'foo';
         XH_writeFile($filename, $expected);

--- a/tests/unit/HeadTest.php
+++ b/tests/unit/HeadTest.php
@@ -59,7 +59,8 @@ class HeadTest extends TestCase
             'meta' => array('robots' => 'index, follow'),
             'site' => array(
                 'title' => ''
-            )
+            ),
+            'head' => array('links' => 'true'),
         );
         $tx = array(
             'meta' => array('keywords' => 'CMSimple, XH')
@@ -160,7 +161,7 @@ class HeadTest extends TestCase
      * remove for 1.8
      * https://github.com/cmsimple-xh/cmsimple-xh/issues/285
      */
-    /*public function testRendersPrevLink()
+    public function testRendersPrevLink()
     {
         $this->titleMock->expects($this->any())->willReturn("");
         $findPreviousPageMock = $this->createFunctionMock('XH_findPreviousPage');
@@ -173,7 +174,7 @@ class HeadTest extends TestCase
         );
         $getPageUrlMock->restore();
         $findPreviousPageMock->restore();
-    }*/
+    }
 
     /**
      * Tests that the next page link is rendered.
@@ -182,7 +183,7 @@ class HeadTest extends TestCase
      * remove for 1.8
      * https://github.com/cmsimple-xh/cmsimple-xh/issues/285
      */
-    /*public function testRendersNextLink()
+    public function testRendersNextLink()
     {
         $this->titleMock->expects($this->any())->willReturn("");
         $findNextPageMock = $this->createFunctionMock('XH_findNextPage');
@@ -195,7 +196,7 @@ class HeadTest extends TestCase
         );
         $getPageUrlMock->restore();
         $findNextPageMock->restore();
-    }*/
+    }
 
     /**
      * Tests that the template stylesheet link element is rendered.

--- a/tests/unit/LinkCheckerTest.php
+++ b/tests/unit/LinkCheckerTest.php
@@ -57,10 +57,10 @@ class LinkCheckerTest extends TestCase
         );
         $cf = array(
             'mailform' => array('email' => 'devs@cmsimple-xh.org'),
-            'link' => [
+            'validate' => [
                 'mailto' => "true",
                 'tel' => "true"
-            ]
+            ],
         );
         $onload = '';
         $this->linkChecker = $this->getMockBuilder(LinkChecker::class)

--- a/tests/unit/PageDataModelTest.php
+++ b/tests/unit/PageDataModelTest.php
@@ -28,6 +28,7 @@ class PageDataModelTest extends TestCase
         global $cf;
 
         $cf['uri']['word_separator'] = '-';
+        $cf['uri']['transliteration'] = '';
         $h = array('Welcome', 'News');
         $fields = array('url', 'foo', 'bar', 'list');
         $temp = array('url' => 'deleted', 'foo' => '', 'bar' => '', 'baz' => 42);

--- a/tests/unit/PageDataRouterTest.php
+++ b/tests/unit/PageDataRouterTest.php
@@ -28,6 +28,7 @@ class PageDataRouterTest extends TestCase
         global $cf;
 
         $cf['uri']['word_separator'] = '-';
+        $cf['uri']['transliteration'] = '';
         $h = array('Welcome', 'News');
         $fields = array('url', 'foo', 'bar', 'list');
         $temp = array('url' => 'deleted', 'foo' => '', 'bar' => '', 'baz' => 42);

--- a/tests/unit/PluginTextFileEditTest.php
+++ b/tests/unit/PluginTextFileEditTest.php
@@ -121,6 +121,7 @@ class PluginTextFileEditTest extends TestCase
         );
         $exitSpy = $this->createFunctionMock('XH_exit');
         $exitSpy->expects($this->once());
+        $_SESSION = ['xh_default_password' => ''];
         $_POST = array('plugin_text' => 'body{}');
         $this->subject->submit();
         $headerSpy->restore();


### PR DESCRIPTION
So sieht es doch wieder ganz ordentlich aus. :)

Der PR enthält bereits das Upgrade auf Ubuntu 22.04 (sonst wäre die CI in meinem Repo nicht gelaufen), das auch in #658 enthalten ist (sollte aber keine Merge-Konflikte geben, denke ich).

Die Warnings, die PHPUnit nun anzeigt, sollten mit #655 behoben sein.

Eine Line-Coverage von knapp 50% ist zwar mager, aber besser als nichts (zumindest wird der Code ausgeführt, was bei neuen PHP-Version schon mal das ein oder andere Problem aufzeigen sollte).
 