### PR TITLE
Defer $hjs injection till final clean-up

### DIFF
--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -403,7 +403,7 @@ function editor_replace($elementID = false, $config = '')
  */
 function XH_finalCleanUp($html)
 {
-    global $errors, $cf, $tx, $bjs;
+    global $errors, $cf, $tx, $hjs, $bjs;
 
     if (XH_ADM === true) {
         $debugHint = '';
@@ -443,6 +443,9 @@ function XH_finalCleanUp($html)
         $html = preg_replace('~<body[^>]*>~i', $replacement, $html, 1);
     }
 
+    if (!empty($hjs)) {
+        $html = str_replace('<!--{11DF30E2-DDD5-4250-8F6B-C9E1147218A1}-->', $hjs, $html);
+    }
     if (!empty($bjs)) {
         $html = str_replace('</body', "$bjs\n</body", $html);
     }

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -444,7 +444,7 @@ function XH_finalCleanUp($html)
     }
 
     if (!empty($hjs)) {
-        $html = str_replace('<!--{11DF30E2-DDD5-4250-8F6B-C9E1147218A1}-->', $hjs, $html);
+        $html = str_replace('<!--$hjs here-->', $hjs, $html);
     }
     if (!empty($bjs)) {
         $html = str_replace('</body', "$bjs\n</body", $html);

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -53,7 +53,7 @@ function XH_renderNextLink()
  */
 function head()
 {
-    global $title, $cf, $pth, $tx, $hjs;
+    global $title, $cf, $pth, $tx;
 
     $t = XH_title($cf['site']['title'], $title);
     $t = '<title>' . strip_tags($t) . '</title>' . "\n";
@@ -75,7 +75,7 @@ function head()
     }
     $o .= '<link rel="stylesheet" href="' . XH_pluginStylesheet()
         . '" type="text/css">' . PHP_EOL
-        . $hjs
+        . '<!--{11DF30E2-DDD5-4250-8F6B-C9E1147218A1}-->' // $hjs replacement
         . '<link rel="stylesheet" href="' . $pth['file']['stylesheet']
         . '" type="text/css">' . "\n";
     return $o;

--- a/cmsimple/tplfuncs.php
+++ b/cmsimple/tplfuncs.php
@@ -75,7 +75,7 @@ function head()
     }
     $o .= '<link rel="stylesheet" href="' . XH_pluginStylesheet()
         . '" type="text/css">' . PHP_EOL
-        . '<!--{11DF30E2-DDD5-4250-8F6B-C9E1147218A1}-->' // $hjs replacement
+        . '<!--$hjs here-->' // $hjs replacement
         . '<link rel="stylesheet" href="' . $pth['file']['stylesheet']
         . '" type="text/css">' . "\n";
     return $o;


### PR DESCRIPTION
Traditionally, `$hjs` has been written to `<head>` when `head()` was called.  That makes `$hjs` basically unusable if a plugin call is supposed to be put in the `<body>` of the template.  While there are some workarounds, sometimes elements must be placed in `<head>`.

Therefore, we do no longer write `$hjs` directly in `head()`, but only put a placeholder there, which we replace in `XH_finalCleanUp()`.

Alternatives:

* don't use a placeholder, but replace like it's done for `$bjs`
* use a "simpler" placeholder than an UUID, e.g. `<!--$hjs here-->`

We're choosing to do it this way, to (a) provide maximum backward compatibility (changing the order of elements in `<head>` might cause issues), and (b) to further reduce the risk that the placeholder is inadvertently overwritten by a plugin (highly unlikely, though).

See also <https://cmsimpleforum.com/viewtopic.php?t=13988&p=92323#p67412>.