### PR TITLE
Fix test failures due to 3f6f770f27c4d3482d8e1205f12705915f81f280

### DIFF
--- a/tests/unit/ControllerLoginTest.php
+++ b/tests/unit/ControllerLoginTest.php
@@ -56,13 +56,14 @@ class ControllerLoginTest extends ControllerLogInOutTestCase
         global $pth, $cf;
 
         parent::setUp();
+        vfsStream::setup('root');
         $_SERVER = array(
             'HTTP_USER_AGENT' => 'Mozilla/5.0',
             'REMOTE_ADDR' => '127.0.0.1'
         );
         $pth = array(
             'folder' => ['cmsimple' => './cmsimple/', 'downloads' => './userfiles/downloads'],
-            'file' => ['log' => ''],
+            'file' => ['config' => vfsStream::url('root/config.php'), 'log' => ''],
         );
         $this->passwordVerifyMock = $this->createFunctionMock('password_verify');
         $cf['security']['password'] = '$P$BHYRVbjeM5YAvnwX2AkXnyqjLhQAod1';


### PR DESCRIPTION
Just the most basic fix to get these tests to green.

---

See https://github.com/cmb69/cmsimple-xh/actions/runs/15255658476.