### PR TITLE
Upgrade some dev tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php_version: ['8.1', '8.0', '7.4', '7.3', '7.2']
+        php_version: ['8.2', '8.1', '8.0', '7.4']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/build.xml
+++ b/build.xml
@@ -10,7 +10,9 @@
     </fileset>
 
     <target name="help" description="lists available targets">
-        <exec command="phing -l" outputProperty="help"/>
+        <exec executable="phing" outputProperty="help">
+            <arg line="-l"/>
+        </exec>
         <echo>${help}</echo>
     </target>
 
@@ -37,7 +39,7 @@
     </target>
 
     <target name="phan" description="run Phan static analysis">
-        <exec command="phan" passthru="true" logoutput="true" checkreturn="true"/>
+        <exec executable="phan" passthru="true" logoutput="true" checkreturn="true"/>
     </target>
 
     <target name="unit-tests" description="runs all unit tests">
@@ -46,37 +48,47 @@
 
     <target name="validation-tests" description="runs all validation tests">
         <fail unless="env.CMSIMPLEDIR" message="CMSIMPLEDIR undefined!"/>
-        <exec command="phpunit --bootstrap tests/bootstrap.php tests/validation" passthru="true" checkreturn="true"/>
+        <exec executable="phpunit" passthru="true" checkreturn="true">
+            <arg line="--bootstrap tests/bootstrap.php tests/validation"/>
+        </exec>
     </target>
 
     <target name="attack-tests" description="runs all attack tests">
         <fail unless="env.CMSIMPLEDIR" message="CMSIMPLEDIR undefined!"/>
-        <exec command="phpunit --bootstrap tests/bootstrap.php tests/attack" passthru="true" checkreturn="true"/>
+        <exec executable="phpunit" passthru="true" checkreturn="true">
+            <arg line="--bootstrap tests/bootstrap.php tests/attack"/>
+        </exec>
     </target>
 
     <target name="all-tests" depends="unit-tests,validation-tests,attack-tests"
             description="runs all tests"/>
 
     <target name="coverage" description="generates coverage report">
-        <exec command="phpdbg -qrr vendor/phpunit/phpunit/phpunit --configuration phpunit.xml"
-              passthru="true" logoutput="true"/>
+        <exec executable="phpdbg" passthru="true" logoutput="true">
+            <arg line="-qrr vendor/phpunit/phpunit/phpunit --configuration phpunit.xml"/>
+        </exec>
     </target>
 
     <target name="php-doc">
         <mkdir dir="doc/php"/>
-        <exec command="doxygen Doxyfile" passthru="true" checkreturn="true"/>
+        <exec executable="doxygen" passthru="true" checkreturn="true">
+            <arg file="Doxyfile"/>
+        </exec>
     </target>
 
     <target name="js-doc">
-        <exec command="jsdoc --destination doc/js assets/js/admin.min.js"
-              passthru="true" checkreturn="true"/>
+        <exec executable="jsdoc" passthru="true" checkreturn="true">
+            <arg line="--destination doc/js assets/js/admin.min.js"/>
+        </exec>
     </target>
 
     <target name="doc" depends="php-doc,js-doc" description="generates the developer documentation"/>
 
     <target name="build" description="builds a distributable ZIP archive">
         <fail unless="version" message="version is not defined!"/>
-        <exec command="git archive -o export.zip HEAD" checkreturn="true"/>
+        <exec executable="git" checkreturn="true">
+            <arg line="archive -o export.zip HEAD"/>
+        </exec>
         <unzip file="export.zip" todir="export"/>
         <delete file="export.zip"/>
         <tstamp>

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
     "require-dev": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "ext-curl": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-session": "*",
-        "phing/phing": "^2.17.0",
+        "phing/phing": "^3.0",
         "squizlabs/php_codesniffer": "^3.6.0",
         "phpmd/phpmd": "^2.10.2",
-        "phpunit/phpunit": "8.5.*",
+        "phpunit/phpunit": "^9.6",
         "mikey179/vfsstream": "^1.6.10",
         "tedivm/jshrink": "^1.4.0",
         "phan/phan": "5.4.*"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         convertDeprecationsToExceptions="true"
-         backupGlobals="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests/unit</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php" cacheResultFile=".phpunit.cache/test-results" executionOrder="depends,defects" forceCoversAnnotation="false" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" beStrictAboutTestsThatDoNotTestAnything="false" convertDeprecationsToExceptions="true" backupGlobals="true" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests/unit</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/unit/FunctionsTest.php
+++ b/tests/unit/FunctionsTest.php
@@ -360,6 +360,7 @@ class FunctionsTest extends TestCase
 
         $expected = array('de', 'fr');
         $pth['folder']['base'] = './tests/unit/data/';
+        uopz_set_static('XH_secondLanguages', ['langs' => null]);
         $actual = XH_secondLanguages();
         $this->assertEquals($expected, $actual);
     }
@@ -383,9 +384,11 @@ class FunctionsTest extends TestCase
      */
     public function testIsInternalPath($path, $language, $expected)
     {
-        global $sl;
+        global $sl, $pth;
 
+        uopz_set_static('XH_secondLanguages', ['langs' => null]);
         $sl = $language;
+        $pth['folder']['base'] = './tests/unit/data/';
         $actual = XH_isInternalPath($path);
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
First, we upgrade to Phing 3, what requires PHP ≥ 7,4 which is not a problem since that version is required by CMSimple_XH 1.8 anyway.

Then we need to upgrade to PHPUnit 9, since otherwise there are install conflicts.  That requires us two touch two test cases, because we need to reset a function scope static variable.

We now also run CI (if it runs) on PHP 8.2; PHP 8.3 and 8.4 are likely out of reach for now, since there are issues regarding uopz.

---

The [four failing tests](https://github.com/cmb69/cmsimple-xh/actions/runs/15256688526/job/42905909310) are adressed by #661 already.

