### PR TITLE
Remove CI (check) badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CMSimple_XH – a flat file CMS
 
 [![stable: 1.8.0](https://img.shields.io/badge/stable-1.8.0-green.svg)](https://github.com/cmsimple-xh/cmsimple-xh/releases)
-![CI](https://github.com/cmsimple-xh/cmsimple-xh/actions/workflows/ci.yml/badge.svg?branch=1.7)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 
 CMSimple_XH is a fast, small, easy-to-use and


### PR DESCRIPTION
Makes no sense to have it, if we don't run CI.