### PR TITLE
Extend build workflow to also build a patch file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ on:
         description: The branch, tag or SHA to checkout
         required: true
         default: master
+      patchee:
+        description: Against which CMSimple_XH version the patch should be built (e.g. 1.8)
+        default: ''
+      patchee-tag:
+        description: The tag of the patchee (e.g. 1.8.0); blank to use patchee
+        default: ''
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -26,8 +32,21 @@ jobs:
         run: composer install
       - name: Build CMSimple_XH
         run: PATH=vendor/bin:$PATH phing build -Dversion=${{github.event.inputs.version}}
-      - name: Unzip build
-        run: unzip CMSimple_XH-${{github.event.inputs.version}}.zip -d artifacts
+      - if: github.event.inputs.patchee != ''
+        name: Download Patchee
+        run: |
+          curl -fsSL -o CMSimple_XH-${{github.event.inputs.patchee}}.zip https://github.com/cmsimple-xh/cmsimple-xh/releases/download/${{github.event.inputs.patchee-tag || github.event.inputs.patchee}}/CMSimple_XH-${{github.event.inputs.patchee}}.zip
+      - if: github.event.inputs.patchee != ''
+        name: Build patch
+        run: |
+          PATH=vendor/bin:$PATH phing build-patch -Dversion=${{github.event.inputs.version}} -Dpatchee=CMSimple_XH-${{github.event.inputs.patchee}}.zip
+      - name: Move build to artifacts folder
+        run: |
+          mkdir artifacts
+          mv CMSimple_XH-${{github.event.inputs.version}}.zip artifacts
+          if [ -f CMSimple_XH-${{github.event.inputs.version}}-patch.zip ]; then
+            mv CMSimple_XH-${{github.event.inputs.version}}-patch.zip artifacts
+          fi
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Versions are configurable now. A test build in my fork worked quite well (after a couple of attempts). If two patches are needed, two builds can be done.
