### PR TITLE
Use autofocus attribute instead of JS

### DIFF
--- a/cmsimple/classes/PasswordForgotten.php
+++ b/cmsimple/classes/PasswordForgotten.php
@@ -50,7 +50,7 @@ class PasswordForgotten
      */
     private function render()
     {
-        global $title, $o, $sn, $tx, $onload;
+        global $title, $o, $sn, $tx;
 
         $title = $tx['title']['password_forgotten'];
         $o .= '<div class="xh_login">'
@@ -66,11 +66,9 @@ class PasswordForgotten
                 $o .= '<p>' . $tx['password_forgotten']['request'] . '</p>'
                 . '<form name="xh_forgotten" action="' . $sn . '?&function=forgotten"'
                 . ' method="post">'
-                . '<input type="text" name="xh_email">'
+                . '<input type="text" name="xh_email" autofocus>'
                 . '<input type="submit" class="submit" value="Send Reminder">'
                 . '</form>';
-                $onload .= 'document.forms[\'xh_forgotten\'].elements[\'xh_email\']'
-                    . '.focus();';
         }
         $o .= '</div>';
     }

--- a/cmsimple/functions.php
+++ b/cmsimple/functions.php
@@ -1370,11 +1370,10 @@ function XH_logMessage($type, $module, $category, $description)
  */
 function loginforms()
 {
-    global $cf, $tx, $onload, $f, $o, $s, $sn, $su, $u, $title, $xh_publisher;
+    global $cf, $tx, $f, $o, $s, $sn, $su, $u, $title, $xh_publisher;
 
     if ($f == 'login' || $f == 'xh_login_failed' || $f == 'xh_login_pw_expired') {
         $cf['meta']['robots'] = "noindex";
-        $onload .= 'document.forms[\'login\'].elements[\'keycut\'].focus();';
         if ($f == 'xh_login_failed') {
             $message = XH_message('fail', $tx['login']['failure']);
         } elseif ($f == 'xh_login_pw_expired') {
@@ -1390,7 +1389,7 @@ function loginforms()
             . '<form id="login" name="login" action="' . $sn . '?' . $su
             . '" method="post">'
             . '<input type="hidden" name="login" value="true">'
-            . '<input type="password" name="keycut" id="passwd" value="">'
+            . '<input type="password" name="keycut" id="passwd" value="" autofocus>'
             . ' '
             . '<input type="submit" name="submit" id="submit" value="'
             . $tx['menu']['login'] . '">'


### PR DESCRIPTION
While the `autofocus` attribute is not supported on iOS Safari, this way we can get rid of using `$onload` in the front-end related functionality of the core, so that CSP `script-src 'self'` can be supported.

---

IMHO a sensible compromise.