### PR TITLE
Stop running CI on PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php_version: ['8.1', '8.0', '7.4', '7.3', '7.2']
+        php_version: ['8.1', '8.0', '7.4']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
We do no longer support these versions, so it makes no sense to have CI for them.